### PR TITLE
fix: honor PRESTAFLOW_USER_AGENT in getBrowser()

### DIFF
--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -352,7 +352,7 @@ class TestsSuite
             //$browserFactory->addOptions(['headless' => (bool) $headless]);
 
             $browser = $browserFactory->createBrowser([
-                'userAgent' => 'PrestaFlow',
+                'userAgent' => $_ENV['PRESTAFLOW_USER_AGENT'] ?? 'PrestaFlow',
                 'keepAlive' => true,
                 'windowSize' => [1920, 1000],
                 'headless' => (bool) $headless,


### PR DESCRIPTION
## Problème

`TestsSuite::before()` appelle `getBrowser()`, qui **hardcode** le User-Agent du navigateur à `'PrestaFlow'` :

```php
// src/Tests/TestsSuite.php (getBrowser)
$browser = $browserFactory->createBrowser([
    'userAgent' => 'PrestaFlow',   // ← hardcodé
    ...
]);
```

Or `_getBrowser()` et la construction des globals honorent déjà `PRESTAFLOW_USER_AGENT` :

```php
// _getBrowser()
'userAgent' => $globals['BROWSER']['USER_AGENT'] ?? 'PrestaFlow',
// globals
'USER_AGENT' => $_ENV['PRESTAFLOW_USER_AGENT'] ?? 'PrestaFlow',
```

Comme `getBrowser()` est le chemin réellement utilisé, il est **impossible** de définir un User-Agent personnalisé.

## Pourquoi c'est gênant

Pour lancer les tests E2E contre un environnement protégé (Cloudflare, WAF…), il faut souvent un UA réaliste : un UA non-navigateur comme `PrestaFlow` est challengé/bloqué par le **Browser Integrity Check** de Cloudflare et consorts. Sans pouvoir surcharger l'UA, la CI hébergée est bloquée.

## Correctif

`getBrowser()` lit désormais `$_ENV['PRESTAFLOW_USER_AGENT']` (fallback `'PrestaFlow'`), comme le reste de la lib. **Rétro-compatible** (comportement identique si la variable n'est pas définie).

On peut alors mettre p.ex. `PRESTAFLOW_USER_AGENT="Mozilla/5.0 ... Chrome/xxx PrestaFlow-<token>"` et allowlister ce token côté WAF.