### PR TITLE
feat: PRESTAFLOW_COOKIES env + page RGPD (bandeau de consentement)

### DIFF
--- a/src/Pages/Common/FrontOffice/Rgpd/Page.php
+++ b/src/Pages/Common/FrontOffice/Rgpd/Page.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace PrestaFlow\Library\Pages\Common\FrontOffice\Rgpd;
+
+use HeadlessChromium\Cookies\Cookie;
+use PrestaFlow\Library\Pages\Common\FrontOffice\Page as BasePage;
+
+/**
+ * Page « RGPD / bandeau de consentement cookies ».
+ *
+ * Cible en priorité le module Knowband « GDPR Cookie » (préfixe `kb-`, cookie
+ * `___kbgdcc`), très répandu, avec un repli générique « tout accepter ».
+ *
+ * Sur un site avec bandeau de consentement, celui-ci se superpose au contenu et
+ * peut fausser les assertions (ex. le `<h1>` du bandeau devient le premier de la
+ * page). Deux stratégies :
+ *  - `preAccept()` : pré-règle le cookie de consentement AVANT navigation
+ *    (le plus fiable — le bandeau ne s'affiche pas) ;
+ *  - `accept()` : clique le bouton d'acceptation si le bandeau est affiché.
+ */
+class Page extends BasePage
+{
+    public function defineSelectors()
+    {
+        return [
+            // Module Knowband GDPR Cookie
+            'knowbandModal'     => '#kb-cookie-setting-modal',
+            'knowbandSavePrefs' => '#kb-cookie-setting-modal .kb-btn',
+            // Repli générique
+            'acceptAll'         => '#cookie-accept, .js-accept-all-cookies, [data-accept-all-cookies]',
+        ];
+    }
+
+    /** true si un bandeau / modal de consentement est visible. */
+    public function isDisplayed(): bool
+    {
+        return $this->isVisible($this->selector('knowbandModal'), 1500)
+            || $this->isVisible($this->selector('acceptAll'), 500);
+    }
+
+    /**
+     * Pré-règle le cookie de consentement Knowband (`___kbgdcc`) pour que le
+     * bandeau ne s'affiche pas. À appeler AVANT la première navigation.
+     *
+     * Astuce : pour rester agnostique, on peut aussi passer par la variable
+     * d'environnement PRESTAFLOW_COOKIES (gérée par TestsSuite).
+     */
+    public function preAccept(string $domain): void
+    {
+        try {
+            $this->getPage()->setCookies([
+                Cookie::create(
+                    '___kbgdcc',
+                    // {"1":{"active":"1","modules":""}} — consentement enregistré.
+                    'eyIxIjp7ImFjdGl2ZSI6IjEiLCJtb2R1bGVzIjoiIn19',
+                    ['domain' => $domain, 'path' => '/', 'secure' => true]
+                ),
+            ]);
+        } catch (\Throwable $e) {
+            // best-effort
+        }
+    }
+
+    /** Clique le bouton d'acceptation si le bandeau est affiché (no-op sinon). */
+    public function accept(): void
+    {
+        foreach (['acceptAll', 'knowbandSavePrefs'] as $selector) {
+            if ($this->isVisible($this->selector($selector), 1000)) {
+                $this->click($this->selector($selector));
+
+                return;
+            }
+        }
+    }
+}

--- a/src/Pages/v7/FrontOffice/Rgpd/Page.php
+++ b/src/Pages/v7/FrontOffice/Rgpd/Page.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PrestaFlow\Library\Pages\v7\FrontOffice\Rgpd;
+
+use PrestaFlow\Library\Pages\Common\FrontOffice\Rgpd\Page as BasePage;
+
+class Page extends BasePage
+{
+}

--- a/src/Pages/v8/FrontOffice/Rgpd/Page.php
+++ b/src/Pages/v8/FrontOffice/Rgpd/Page.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PrestaFlow\Library\Pages\v8\FrontOffice\Rgpd;
+
+use PrestaFlow\Library\Pages\Common\FrontOffice\Rgpd\Page as BasePage;
+
+class Page extends BasePage
+{
+}

--- a/src/Pages/v9/FrontOffice/Rgpd/Page.php
+++ b/src/Pages/v9/FrontOffice/Rgpd/Page.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PrestaFlow\Library\Pages\v9\FrontOffice\Rgpd;
+
+use PrestaFlow\Library\Pages\Common\FrontOffice\Rgpd\Page as BasePage;
+
+class Page extends BasePage
+{
+}

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -391,6 +391,11 @@ class TestsSuite
 
         TestsSuite::getBrowser(headless: $headless, force: true);
 
+        // Pré-réglage de cookies fournis via l'environnement (PRESTAFLOW_COOKIES,
+        // JSON), avant toute navigation. Pratique pour neutraliser un bandeau de
+        // consentement (RGPD) sur un environnement protégé/preprod.
+        $this->presetEnvCookies();
+
         try {
             $cookies = TestsSuite::getPage()?->getCookies();
             if ($cookies instanceof CookiesCollection && count($cookies)) {
@@ -407,6 +412,57 @@ class TestsSuite
         }
 
         $this->start_time = hrtime(true);
+    }
+
+    /**
+     * Pré-règle des cookies fournis via l'environnement, avant toute navigation.
+     *
+     * PRESTAFLOW_COOKIES = tableau JSON d'objets {name, value, domain?, path?, secure?}.
+     * Exemple (neutraliser un bandeau RGPD Knowband) :
+     *   PRESTAFLOW_COOKIES=[{"name":"___kbgdcc","value":"eyIx...","domain":"preprod.example.com"}]
+     *
+     * Best-effort : n'interrompt jamais l'exécution si l'API cookies échoue.
+     */
+    protected function presetEnvCookies(): void
+    {
+        $raw = $_ENV['PRESTAFLOW_COOKIES'] ?? null;
+        if (!$raw) {
+            return;
+        }
+
+        $cookies = \json_decode($raw, true);
+        if (!is_array($cookies)) {
+            return;
+        }
+
+        $page = TestsSuite::getPage();
+        if (!$page) {
+            return;
+        }
+
+        foreach ($cookies as $c) {
+            if (empty($c['name'])) {
+                continue;
+            }
+
+            $params = [];
+            foreach (['domain', 'path', 'secure', 'httpOnly', 'sameSite', 'expires', 'url'] as $key) {
+                if (array_key_exists($key, $c)) {
+                    $params[$key] = $c[$key];
+                }
+            }
+            if (!isset($params['path'])) {
+                $params['path'] = '/';
+            }
+
+            try {
+                $page->setCookies([
+                    Cookie::create($c['name'], (string) ($c['value'] ?? ''), $params),
+                ]);
+            } catch (Throwable $e) {
+                // best-effort
+            }
+        }
     }
 
     public function after()


### PR DESCRIPTION
## Contexte

Tester en E2E un site avec un **bandeau de consentement cookies (RGPD)** est problématique : le bandeau se superpose au contenu et fausse les assertions (typiquement, son `<h1>` « Centre de paramètres des cookies » devient le premier `<h1>` de la page).

Cette PR ajoute **deux approches complémentaires** :

### 1. `PRESTAFLOW_COOKIES` (config, sans code)

Un tableau JSON de cookies que `TestsSuite` pré-règle **avant toute navigation** (dans `before()`, via `setCookies()`) :

```dotenv
PRESTAFLOW_COOKIES=[{"name":"___kbgdcc","value":"eyIx...","domain":"preprod.example.com"}]
```

Générique : marche pour n'importe quel module de consentement / n'importe quel cookie. Chaque entrée accepte `name`, `value`, `domain`, `path`, `secure`, `httpOnly`, `sameSite`, `expires`, `url`. Best-effort (n'interrompt jamais le run).

### 2. Page FrontOffice `Rgpd`

Un page object (`Common` + `v7`/`v8`/`v9`) pour le bandeau, ciblant le module **Knowband GDPR Cookie** (`___kbgdcc`, préfixe `kb-`) avec un repli générique « tout accepter » :

- `isDisplayed()` — le bandeau est-il visible ;
- `preAccept(string $domain)` — pré-règle le cookie de consentement (à appeler avant la 1re navigation) ;
- `accept()` — clique le bouton d'acceptation si affiché (no-op sinon).

## Notes

- Rétro-compatible : sans `PRESTAFLOW_COOKIES`, aucun changement de comportement.
- Les sélecteurs de la page `Rgpd` sont volontairement simples (Knowband + repli) et faciles à étendre pour d'autres modules.