### PR TITLE
fix: await setCookies() in cookie presets

### DIFF
--- a/src/Pages/Common/FrontOffice/Rgpd/Page.php
+++ b/src/Pages/Common/FrontOffice/Rgpd/Page.php
@@ -55,7 +55,7 @@ class Page extends BasePage
                     'eyIxIjp7ImFjdGl2ZSI6IjEiLCJtb2R1bGVzIjoiIn19',
                     ['domain' => $domain, 'path' => '/', 'secure' => true]
                 ),
-            ]);
+            ])->await();
         } catch (\Throwable $e) {
             // best-effort
         }

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -458,7 +458,7 @@ class TestsSuite
             try {
                 $page->setCookies([
                     Cookie::create($c['name'], (string) ($c['value'] ?? ''), $params),
-                ]);
+                ])->await();
             } catch (Throwable $e) {
                 // best-effort
             }


### PR DESCRIPTION
Sans await, le cookie pré-réglé (PRESTAFLOW_COOKIES / Rgpd::preAccept) pouvait ne pas être posé avant la 1re navigation. Aligné sur le reste de la lib. Validé contre preprod.