### PR TITLE
fix: résolution des chemins projet en install symlink (path repo Composer)

### DIFF
--- a/bin/prestaflow
+++ b/bin/prestaflow
@@ -2,13 +2,27 @@
 <?php
 
 $autoloadFiles = [
+    // Défini par le proxy de bin Composer (le plus fiable, y compris en symlink).
+    $GLOBALS['_composer_autoload_path'] ?? null,
+    // Install classique : vendor/prestaflow/php-library/bin → vendor/autoload.php
     __DIR__ . '/../../../autoload.php',
+    // Lib autonome (dev direct dans le dépôt de la lib).
     __DIR__ . '/../vendor/autoload.php',
+    // Repli : lib symlinkée (path repo) → __DIR__ pointe hors du vendor du projet,
+    // on retombe sur l'autoload du projet courant.
+    getcwd() . '/vendor/autoload.php',
 ];
+$autoloadLoaded = false;
 foreach ($autoloadFiles as $autoloadFile) {
-    if (file_exists($autoloadFile)) {
+    if ($autoloadFile && file_exists($autoloadFile)) {
         require_once $autoloadFile;
+        $autoloadLoaded = true;
+        break;
     }
+}
+if (!$autoloadLoaded) {
+    fwrite(STDERR, "PrestaFlow : autoload Composer introuvable. Lancez « composer install ».\n");
+    exit(1);
 }
 
 use PrestaFlow\Library\Command\ExecuteSuite;

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -549,6 +549,14 @@ class TestsSuite
 
     public function loadGlobals()
     {
+        // Répertoire de travail courant : le CLI `prestaflow` est lancé depuis la
+        // racine du projet qui consomme la lib, où se trouvent .env / .env.local.
+        // C'est le chemin le plus fiable, y compris quand la lib est installée en
+        // symlink (path repo Composer) — auquel cas __DIR__ pointe hors du projet.
+        // `createImmutable` : la première valeur trouvée gagne → on charge d'abord.
+        $dotenv = Dotenv::createImmutable(getcwd(), ['.env.local', '.env']);
+        $dotenv->safeLoad();
+
         $dotenv = Dotenv::createImmutable(__DIR__.'/../../', ['.env.local', '.env']);
         $dotenv->safeLoad();
         // When importing the library in a project, the .env file is not in the same directory


### PR DESCRIPTION
Deux chemins supposaient une install classique sous `vendor/` et cassaient en consommation **symlink** (composer `path` repository) — `__DIR__` pointe alors hors du projet.

- **bin/prestaflow** : repli `getcwd()/vendor/autoload.php` (+ hint `$_composer_autoload_path`), arrêt au premier autoload trouvé, erreur explicite sinon.
- **TestsSuite::loadGlobals()** : charge `.env`/`.env.local` depuis `getcwd()` en premier (le CLI tourne depuis la racine projet), avant les chemins `__DIR__`.

Aucun effet en install classique (getcwd == racine projet). Débloque le dev de la lib en symlink sans publier de release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)