### PR TITLE
fix: activer Network avant setBasicAuthHeader

### DIFF
--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -7,6 +7,7 @@ use Dotenv\Dotenv;
 use Error;
 use Exception;
 use HeadlessChromium\BrowserFactory;
+use HeadlessChromium\Communication\Message;
 use HeadlessChromium\Cookies\Cookie;
 use HeadlessChromium\Cookies\CookiesCollection;
 use HeadlessChromium\Exception\BrowserConnectionFailed;
@@ -449,6 +450,11 @@ class TestsSuite
         }
 
         try {
+            // Le domaine Network doit être activé pour que setExtraHTTPHeaders
+            // (Network.setExtraHTTPHeaders) prenne effet. La page « about:blank »
+            // auto-créée à la connexion n'est pas passée par le flux d'activation
+            // de BrowserFactory → on l'active explicitement (idempotent).
+            $page->getSession()->sendMessageSync(new Message('Network.enable'));
             $page->setBasicAuthHeader((string) $user, (string) ($pass ?? ''));
         } catch (Throwable $e) {
             // best-effort


### PR DESCRIPTION
`Network.setExtraHTTPHeaders` est sans effet si le domaine `Network` n'est pas activé. La page auto-créée à la connexion ne passe pas par le flux d'activation de `BrowserFactory` → on active `Network` explicitement (idempotent) avant de poser l'en-tête Basic Auth.

Complète #27. Vérifié : `Authorization: Basic` transmis à httpbin.org/headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)