### PR TITLE
fix: réappliquer les en-têtes après le createPage de goToPage

### DIFF
--- a/src/Pages/FrontOfficePage.php
+++ b/src/Pages/FrontOfficePage.php
@@ -48,6 +48,9 @@ class FrontOfficePage extends CommonPage
         $url = $this->getPageURL($page, $params);
         TestsSuite::getPage()->close();
         TestsSuite::getBrowser()->createPage();
+        // La page vient d'être recréée : réappliquer les en-têtes persistants
+        // (ex. Authorization Basic Auth) sinon la navigation part sans eux.
+        TestsSuite::applyExtraHttpHeaders();
         $this->getPage()->navigate($url)->waitForNavigation();
 
         try {

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -75,6 +75,12 @@ class TestsSuite
 
     protected static array $pendingDebugMessages = [];
 
+    /**
+     * En-têtes HTTP à (ré)appliquer sur CHAQUE page, y compris celles recréées par
+     * goToPage (qui ferme puis recrée la page). Alimenté par presetBasicAuth().
+     */
+    public static array $extraHttpHeaders = [];
+
     protected $draft = false;
     protected $groups = 'all';
 
@@ -443,6 +449,9 @@ class TestsSuite
 
         $authHeader = 'Basic '.\base64_encode($user.':'.($pass ?? ''));
 
+        // Mémorisé pour réapplication après chaque (re)création de page (goToPage).
+        TestsSuite::$extraHttpHeaders['Authorization'] = $authHeader;
+
         $browser = TestsSuite::getBrowser();
         if ($browser) {
             try {
@@ -453,17 +462,32 @@ class TestsSuite
             }
         }
 
+        // Applique sur la page courante (première navigation).
+        TestsSuite::applyExtraHttpHeaders();
+    }
+
+    /**
+     * (Ré)applique self::$extraHttpHeaders sur la page courante. À appeler après
+     * toute (re)création de page — notamment dans goToPage — car un en-tête posé
+     * sur une page fermée est perdu. Best-effort.
+     */
+    public static function applyExtraHttpHeaders(): void
+    {
+        if (empty(TestsSuite::$extraHttpHeaders)) {
+            return;
+        }
+
         $page = TestsSuite::getPage();
-        if ($page) {
-            try {
-                // Network doit être activé pour que Network.setExtraHTTPHeaders prenne
-                // effet ; la page « about:blank » initiale n'est pas passée par le flux
-                // d'activation de BrowserFactory → on l'active (idempotent).
-                $page->getSession()->sendMessageSync(new Message('Network.enable'));
-                $page->setExtraHTTPHeaders(['Authorization' => $authHeader]);
-            } catch (Throwable $e) {
-                // best-effort
-            }
+        if (!$page) {
+            return;
+        }
+
+        try {
+            // Network doit être activé pour que Network.setExtraHTTPHeaders prenne effet.
+            $page->getSession()->sendMessageSync(new Message('Network.enable'));
+            $page->setExtraHTTPHeaders(TestsSuite::$extraHttpHeaders);
+        } catch (Throwable $e) {
+            // best-effort
         }
     }
 


### PR DESCRIPTION
Complète #27/#28/#29. En contexte connectToBrowser, les en-têtes de connexion ne sont pas hérités par les pages recréées par goToPage (close+createPage). On mémorise les en-têtes (TestsSuite::$extraHttpHeaders) et on les réapplique via applyExtraHttpHeaders() juste après le createPage. Vérifié sur httpbin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)