### PR TITLE
feat: régression visuelle (visualCheckpoint + comparaison + rapport)

### DIFF
--- a/src/Command/ExecuteSuite.php
+++ b/src/Command/ExecuteSuite.php
@@ -48,6 +48,7 @@ class ExecuteSuite extends Command
             ->addOption('stats', 's', InputOption::VALUE_NONE, 'Show stats')
             ->addOption('file', 'f', InputOption::VALUE_NONE, 'Output to file')
             ->addOption('junit', null, InputOption::VALUE_OPTIONAL, 'Write a JUnit XML report (default path: prestaflow/junit.xml)', false)
+            ->addOption('visual-report', null, InputOption::VALUE_OPTIONAL, 'Écrit un rapport de régression visuelle (HTML)', false)
             ->addOption('draft', 'd', InputOption::VALUE_NEGATABLE, 'Draft mode')
             ->addArgument('folder', InputArgument::OPTIONAL, 'The folder name', 'tests')
             ->addOption(
@@ -261,6 +262,15 @@ class ExecuteSuite extends Command
         if ($junitPath !== null) {
             $this->filePutContents($junitPath, $report->render());
             $this->success('JUnit report saved to ' . $junitPath, newLine: true, force: true);
+        }
+
+        $visualOption = $input->getOption('visual-report');
+        $visualPath = ($visualOption === false) ? null : ($visualOption ?: 'reports/visual/index.html');
+        if ($visualPath !== null) {
+            $visualReport = new \PrestaFlow\Library\Reports\VisualReport();
+            $this->filePutContents($visualPath, $visualReport->renderHtml(\PrestaFlow\Library\Tests\TestsSuite::$visualResults));
+            $this->filePutContents(dirname($visualPath) . '/visual-results.json', $visualReport->renderJson(\PrestaFlow\Library\Tests\TestsSuite::$visualResults));
+            $this->success('Rapport visuel écrit dans ' . $visualPath, newLine: true, force: true);
         }
 
         return $summary->hasFailures() ? Command::FAILURE : Command::SUCCESS;

--- a/src/Expects/Expect.php
+++ b/src/Expects/Expect.php
@@ -25,6 +25,14 @@ class Expect extends ExpectLibrary
     public static $latestScreenshotError = null;
     public static $nbAssertions = 0;
 
+    /** Attaches (chemins relatifs) à joindre au testcase courant (régression visuelle). */
+    public static array $latestAttachments = [];
+
+    public static function setVisualAttachments(array $paths): void
+    {
+        self::$latestAttachments = $paths;
+    }
+
     protected static string $locale = 'en';
     protected static ?array $translations = null;
 

--- a/src/Pages/CommonPage.php
+++ b/src/Pages/CommonPage.php
@@ -211,6 +211,9 @@ class CommonPage
             ])->saveToFile($actualPath);
         } else {
             $node = $this->getPage()->dom()->querySelector($selector);
+            if ($node === null) {
+                throw new \RuntimeException("visualCheckpoint : sélecteur introuvable « {$selector} »");
+            }
             $this->getPage()->screenshotElement($node)->saveToFile($actualPath);
         }
 

--- a/src/Pages/CommonPage.php
+++ b/src/Pages/CommonPage.php
@@ -191,6 +191,60 @@ class CommonPage
         return TestsSuite::getPage();
     }
 
+    /**
+     * Point de contrôle de régression visuelle.
+     * - pas de référence => capture-la (auto-baseline), PASS.
+     * - référence présente => compare (score >= seuil = PASS, sinon FAIL + attaches actual/diff).
+     * $selector null => capture pleine page ; sinon capture de l'élément.
+     */
+    public function visualCheckpoint(string $name, ?string $selector = null, float $threshold = 0.98): void
+    {
+        $file = $name . '.png';
+        $actualPath = \PrestaFlow\Library\Utils\Screenshots::actualPath($file, create: true);
+        $refPath = \PrestaFlow\Library\Utils\Screenshots::referencePath($file, create: true);
+
+        if ($selector === null) {
+            $this->getPage()->screenshot([
+                'captureBeyondViewport' => true,
+                'clip' => $this->getPage()->getFullPageClip(),
+                'format' => 'png',
+            ])->saveToFile($actualPath);
+        } else {
+            $node = $this->getPage()->dom()->querySelector($selector);
+            $this->getPage()->screenshotElement($node)->saveToFile($actualPath);
+        }
+
+        if (!is_file($refPath)) {
+            copy($actualPath, $refPath);
+            \PrestaFlow\Library\Tests\TestsSuite::recordVisualResult([
+                'name' => $name, 'status' => 'baseline', 'score' => null, 'threshold' => $threshold,
+                'reference' => $refPath, 'actual' => $actualPath, 'diff' => null,
+            ]);
+            \PrestaFlow\Library\Expects\Expect::that(true)->isTheSameAs(true);
+            return;
+        }
+
+        $comparator = new \PrestaFlow\Library\Visual\VisualComparator();
+        $score = $comparator->compare($refPath, $actualPath);
+        $diffPath = \PrestaFlow\Library\Utils\Screenshots::diffPath($file, create: true);
+        $comparator->generateDiff($refPath, $actualPath, $diffPath);
+
+        $status = $score >= $threshold ? 'pass' : 'fail';
+        \PrestaFlow\Library\Tests\TestsSuite::recordVisualResult([
+            'name' => $name, 'status' => $status, 'score' => $score, 'threshold' => $threshold,
+            'reference' => $refPath, 'actual' => $actualPath, 'diff' => $diffPath,
+        ]);
+
+        if ($status === 'fail') {
+            \PrestaFlow\Library\Expects\Expect::setVisualAttachments([
+                \PrestaFlow\Library\Utils\Screenshots::relativeVisualPath('actual', $file),
+                \PrestaFlow\Library\Utils\Screenshots::relativeVisualPath('diff', $file),
+            ]);
+        }
+
+        \PrestaFlow\Library\Expects\Expect::that($score >= $threshold)->isTheSameAs(true);
+    }
+
     public function pageTitle()
     {
         return $this->translate($this->pageTitle);

--- a/src/Reports/JUnitReport.php
+++ b/src/Reports/JUnitReport.php
@@ -87,6 +87,14 @@ final class JUnitReport
                 $sysOut->appendChild($doc->createTextNode('[[ATTACHMENT|' . $relative . ']]'));
                 $caseEl->appendChild($sysOut);
             }
+
+            $attachments = $test['attachments'] ?? [];
+            if (is_array($attachments) && $attachments !== []) {
+                $sysOut = $doc->createElement('system-out');
+                $lines = array_map(static fn ($p) => '[[ATTACHMENT|' . $p . ']]', $attachments);
+                $sysOut->appendChild($doc->createTextNode(implode("\n", $lines)));
+                $caseEl->appendChild($sysOut);
+            }
         } elseif (in_array($state, ['skip', 'skipped', 'todo'], true)) {
             $caseEl->appendChild($doc->createElement('skipped'));
         }

--- a/src/Reports/VisualReport.php
+++ b/src/Reports/VisualReport.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace PrestaFlow\Library\Reports;
+
+final class VisualReport
+{
+    public function renderHtml(array $results): string
+    {
+        $counts = ['pass' => 0, 'fail' => 0, 'baseline' => 0];
+        foreach ($results as $r) { $counts[$r['status']] = ($counts[$r['status']] ?? 0) + 1; }
+
+        $rows = '';
+        foreach ($results as $r) { $rows .= $this->row($r); }
+
+        $head = '<!doctype html><html lang="fr"><head><meta charset="utf-8">'
+            . '<meta name="viewport" content="width=device-width, initial-scale=1">'
+            . '<title>Régression visuelle</title><style>'
+            . 'body{font-family:system-ui,sans-serif;margin:2rem;color:#1a1a1a}'
+            . 'h1{font-size:20px}.sum{display:flex;gap:1rem;margin:1rem 0}'
+            . '.card{border:1px solid #e2e2e2;border-radius:10px;padding:1rem;margin:1rem 0}'
+            . '.hd{display:flex;justify-content:space-between;align-items:center;margin-bottom:.75rem}'
+            . '.badge{font-size:12px;padding:3px 10px;border-radius:6px}'
+            . '.pass{background:#e1f5ee;color:#0f6e56}.fail{background:#fceceb;color:#a32d2d}'
+            . '.baseline{background:#e6f1fb;color:#0c447c}'
+            . '.imgs{display:grid;grid-template-columns:repeat(3,1fr);gap:.75rem}'
+            . '.imgs figure{margin:0}.imgs img{width:100%;border:1px solid #e2e2e2;border-radius:6px}'
+            . '.cap{font-size:12px;color:#666;margin-bottom:4px}</style></head><body>';
+
+        $summary = '<h1>Régression visuelle</h1><div class="sum">'
+            . '<div>Conformes : <strong>' . $counts['pass'] . '</strong></div>'
+            . '<div>Écarts : <strong>' . $counts['fail'] . '</strong></div>'
+            . '<div>Baselines : <strong>' . $counts['baseline'] . '</strong></div></div>';
+
+        return $head . $summary . $rows . '</body></html>';
+    }
+
+    public function renderJson(array $results): string
+    {
+        $out = array_map(static fn ($r) => [
+            'name' => $r['name'], 'status' => $r['status'], 'score' => $r['score'],
+        ], $results);
+        return json_encode($out, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+
+    private function row(array $r): string
+    {
+        $status = $r['status'];
+        $scoreTxt = $r['score'] === null ? '—' : number_format($r['score'] * 100, 1) . ' %';
+        $label = $status === 'baseline' ? 'baseline créée' : ($status === 'pass' ? 'conforme' : 'écart');
+
+        $imgs = '';
+        foreach (['reference' => 'Référence', 'actual' => 'Actuelle', 'diff' => 'Diff'] as $key => $cap) {
+            if (!empty($r[$key]) && is_file($r[$key])) {
+                $imgs .= '<figure><div class="cap">' . $cap . '</div><img alt="' . htmlspecialchars($cap)
+                    . '" src="data:image/png;base64,' . base64_encode(file_get_contents($r[$key])) . '"></figure>';
+            }
+        }
+
+        return '<div class="card"><div class="hd"><strong>' . htmlspecialchars($r['name']) . '</strong>'
+            . '<span>score ' . $scoreTxt . ' <span class="badge ' . $status . '">' . $label . '</span></span></div>'
+            . '<div class="imgs">' . $imgs . '</div></div>';
+    }
+}

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -841,6 +841,9 @@ class TestsSuite
                     $this->stats['failures']++;
                     $this->failed = true;
                 } finally {
+                    // Reset structurel : aucune attache visuelle ne fuite d'un test
+                    // à l'autre, quel que soit l'état (pass compris).
+                    Expect::$latestAttachments = [];
                     $test['expect'] = Expect::getExpectMessage();
                     $this->attachDebugMessages($test);
                     Expect::getNbAssertions();
@@ -927,7 +930,6 @@ class TestsSuite
         $this->screens[] = $test['screen'];
 
         $test['attachments'] = Expect::$latestAttachments ?? [];
-        Expect::$latestAttachments = [];
 
         if (!empty(Expect::$latestScreenshotError)) {
             $this->log('Screenshot capture failed: ' . Expect::$latestScreenshotError);

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -75,6 +75,14 @@ class TestsSuite
 
     protected static array $pendingDebugMessages = [];
 
+    /** Résultats de régression visuelle du run courant (alimentés par CommonPage::visualCheckpoint). */
+    public static array $visualResults = [];
+
+    public static function recordVisualResult(array $result): void
+    {
+        self::$visualResults[] = $result;
+    }
+
     /**
      * En-têtes HTTP à (ré)appliquer sur CHAQUE page, y compris celles recréées par
      * goToPage (qui ferme puis recrée la page). Alimenté par presetBasicAuth().
@@ -917,6 +925,9 @@ class TestsSuite
     {
         $test['screen'] = Expect::$latestError;
         $this->screens[] = $test['screen'];
+
+        $test['attachments'] = Expect::$latestAttachments ?? [];
+        Expect::$latestAttachments = [];
 
         if (!empty(Expect::$latestScreenshotError)) {
             $this->log('Screenshot capture failed: ' . Expect::$latestScreenshotError);

--- a/src/Utils/Screenshots.php
+++ b/src/Utils/Screenshots.php
@@ -7,13 +7,22 @@ final class Screenshots
     public const ERRORS_SUBPATH = 'screens/errors';
     public const RELATIVE_DIR = 'prestaflow/screens/errors';
 
-    public static function errorsDir(bool $create = false): string
+    public const REFERENCES_SUBPATH = 'screens/references';
+    public const ACTUAL_SUBPATH = 'screens/actual';
+    public const DIFF_SUBPATH = 'screens/diff';
+
+    private static function baseDir(): string
     {
         if (function_exists('storage_path')) {
-            $dir = rtrim(storage_path(), '/') . '/' . self::ERRORS_SUBPATH;
-        } else {
-            $dir = getcwd() . '/' . self::RELATIVE_DIR;
+            return rtrim(storage_path(), '/');
         }
+
+        return getcwd() . '/prestaflow';
+    }
+
+    public static function errorsDir(bool $create = false): string
+    {
+        $dir = self::baseDir() . '/' . self::ERRORS_SUBPATH;
 
         if ($create && !is_dir($dir)) {
             mkdir($dir, 0777, true);
@@ -30,6 +39,37 @@ final class Screenshots
     public static function relativeErrorPath(string $filename): string
     {
         return self::RELATIVE_DIR . '/' . $filename;
+    }
+
+    public static function referencePath(string $fileName, bool $create = false): string
+    {
+        return self::visualPath(self::REFERENCES_SUBPATH, $fileName, $create);
+    }
+
+    public static function actualPath(string $fileName, bool $create = false): string
+    {
+        return self::visualPath(self::ACTUAL_SUBPATH, $fileName, $create);
+    }
+
+    public static function diffPath(string $fileName, bool $create = false): string
+    {
+        return self::visualPath(self::DIFF_SUBPATH, $fileName, $create);
+    }
+
+    public static function relativeVisualPath(string $kind, string $fileName): string
+    {
+        return 'prestaflow/screens/' . $kind . '/' . $fileName;
+    }
+
+    private static function visualPath(string $subpath, string $fileName, bool $create): string
+    {
+        $full = self::baseDir() . '/' . $subpath . '/' . $fileName;
+
+        if ($create && !is_dir(dirname($full))) {
+            mkdir(dirname($full), 0777, true);
+        }
+
+        return $full;
     }
 
     public static function captureDelay(): int

--- a/src/Visual/VisualComparator.php
+++ b/src/Visual/VisualComparator.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace PrestaFlow\Library\Visual;
+
+use SapientPro\ImageComparator\ImageComparator;
+
+class VisualComparator
+{
+    private ImageComparator $comparator;
+
+    public function __construct()
+    {
+        $this->comparator = new ImageComparator();
+    }
+
+    /** Score de similarité 0–1 (1 = identiques). Accepte des chemins de fichiers. */
+    public function compare(string $referencePath, string $actualPath): float
+    {
+        $raw = (float) $this->comparator->compare($referencePath, $actualPath);
+        // Normaliser en 0–1 quel que soit le domaine de sortie de la lib (0–1 ou 0–100).
+        return $raw > 1.0 ? $raw / 100.0 : $raw;
+    }
+
+    /** PNG de diff : actuelle grisée, pixels différant de la référence peints en rouge. */
+    public function generateDiff(string $referencePath, string $actualPath, string $diffPath, int $tolerance = 40): void
+    {
+        $ref = $this->load($referencePath);
+        $act = $this->load($actualPath);
+        $w = imagesx($ref);
+        $h = imagesy($ref);
+        if (imagesx($act) !== $w || imagesy($act) !== $h) {
+            $resized = imagecreatetruecolor($w, $h);
+            imagecopyresampled($resized, $act, 0, 0, 0, 0, $w, $h, imagesx($act), imagesy($act));
+            imagedestroy($act);
+            $act = $resized;
+        }
+        $out = imagecreatetruecolor($w, $h);
+        $red = imagecolorallocate($out, 220, 40, 40);
+        for ($y = 0; $y < $h; $y++) {
+            for ($x = 0; $x < $w; $x++) {
+                $ra = imagecolorat($ref, $x, $y);
+                $aa = imagecolorat($act, $x, $y);
+                $d = abs((($ra >> 16) & 0xFF) - (($aa >> 16) & 0xFF)) + abs((($ra >> 8) & 0xFF) - (($aa >> 8) & 0xFF)) + abs(($ra & 0xFF) - ($aa & 0xFF));
+                if ($d > $tolerance) {
+                    imagesetpixel($out, $x, $y, $red);
+                } else {
+                    $g = (int) (((((($aa >> 16) & 0xFF) + (($aa >> 8) & 0xFF) + ($aa & 0xFF)) / 3) * 0.35) + 165);
+                    imagesetpixel($out, $x, $y, imagecolorallocate($out, $g, $g, $g));
+                }
+            }
+        }
+        if (!is_dir(dirname($diffPath))) {
+            mkdir(dirname($diffPath), 0777, true);
+        }
+        imagepng($out, $diffPath);
+        imagedestroy($ref);
+        imagedestroy($act);
+        imagedestroy($out);
+    }
+
+    private function load(string $path)
+    {
+        $img = @imagecreatefrompng($path);
+        if ($img === false) {
+            throw new \RuntimeException('Image PNG illisible : ' . $path);
+        }
+        return $img;
+    }
+}

--- a/tests/Unit/Reports/JUnitReportTest.php
+++ b/tests/Unit/Reports/JUnitReportTest.php
@@ -101,4 +101,27 @@ final class JUnitReportTest extends TestCase
         $this->assertFalse(isset($case->{'system-out'}));
         $this->assertStringNotContainsString('Screenshot:', (string) $case->failure['message']);
     }
+
+    public function testMultipleAttachmentsOnFailure(): void
+    {
+        $report = new \PrestaFlow\Library\Reports\JUnitReport();
+        $report->addSuite([
+            'suite' => 'Tests\\Visual\\Suites\\VisualRegressionTestSuite',
+            'title' => 'Régression visuelle',
+            'stats' => ['failures' => 1, 'time' => 1000],
+            'tests' => [[
+                'title' => 'login',
+                'state' => 'fail',
+                'time' => 500,
+                'expect' => ['fail' => ['score 0.82 < 0.98']],
+                'attachments' => [
+                    'prestaflow/screens/actual/login.png',
+                    'prestaflow/screens/diff/login.png',
+                ],
+            ]],
+        ]);
+        $xml = $report->render();
+        $this->assertStringContainsString('[[ATTACHMENT|prestaflow/screens/actual/login.png]]', $xml);
+        $this->assertStringContainsString('[[ATTACHMENT|prestaflow/screens/diff/login.png]]', $xml);
+    }
 }

--- a/tests/Unit/Reports/VisualReportTest.php
+++ b/tests/Unit/Reports/VisualReportTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PrestaFlow\Tests\Unit\Reports;
+
+use PHPUnit\Framework\TestCase;
+use PrestaFlow\Library\Reports\VisualReport;
+
+final class VisualReportTest extends TestCase
+{
+    private function tmpPng(): string
+    {
+        $p = tempnam(sys_get_temp_dir(), 'pf') . '.png';
+        $img = imagecreatetruecolor(4, 4);
+        imagepng($img, $p); imagedestroy($img);
+        return $p;
+    }
+
+    public function testHtmlContainsCheckpointAndImages(): void
+    {
+        $ref = $this->tmpPng(); $actual = $this->tmpPng(); $diff = $this->tmpPng();
+        $html = (new VisualReport())->renderHtml([
+            ['name'=>'login','status'=>'fail','score'=>0.82,'threshold'=>0.98,'reference'=>$ref,'actual'=>$actual,'diff'=>$diff],
+            ['name'=>'header','status'=>'baseline','score'=>null,'threshold'=>0.98,'reference'=>$ref,'actual'=>null,'diff'=>null],
+        ]);
+        $this->assertStringContainsString('login', $html);
+        $this->assertStringContainsString('data:image/png;base64,', $html);
+        $this->assertStringContainsString('82', $html);
+        $this->assertStringContainsString('baseline', $html);
+    }
+
+    public function testJsonSummary(): void
+    {
+        $json = (new VisualReport())->renderJson([
+            ['name'=>'login','status'=>'pass','score'=>0.99,'threshold'=>0.98,'reference'=>null,'actual'=>null,'diff'=>null],
+        ]);
+        $data = json_decode($json, true);
+        $this->assertSame('login', $data[0]['name']);
+        $this->assertSame('pass', $data[0]['status']);
+    }
+}

--- a/tests/Unit/Utils/ScreenshotsTest.php
+++ b/tests/Unit/Utils/ScreenshotsTest.php
@@ -75,4 +75,22 @@ final class ScreenshotsTest extends TestCase
         $_ENV['PRESTAFLOW_SCREENSHOT_DELAY'] = '-2';
         $this->assertSame(0, Screenshots::captureDelay());
     }
+
+    public function testVisualPathsResolveUnderSubdirs(): void
+    {
+        $this->assertStringEndsWith('/screens/references/login.png', Screenshots::referencePath('login.png'));
+        $this->assertStringEndsWith('/screens/actual/login.png', Screenshots::actualPath('login.png'));
+        $this->assertStringEndsWith('/screens/diff/login.png', Screenshots::diffPath('login.png'));
+    }
+
+    public function testRelativeVisualPath(): void
+    {
+        $this->assertSame('prestaflow/screens/diff/login.png', Screenshots::relativeVisualPath('diff', 'login.png'));
+    }
+
+    public function testCreateMakesParentDir(): void
+    {
+        $path = Screenshots::actualPath('t_' . getmypid() . '.png', create: true);
+        $this->assertDirectoryExists(dirname($path));
+    }
 }

--- a/tests/Unit/Visual/VisualComparatorTest.php
+++ b/tests/Unit/Visual/VisualComparatorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace PrestaFlow\Tests\Unit\Visual;
+
+use PHPUnit\Framework\TestCase;
+use PrestaFlow\Library\Visual\VisualComparator;
+
+final class VisualComparatorTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/pfvis_' . getmypid();
+        @mkdir($this->dir, 0777, true);
+    }
+
+    private function png(string $name, callable $draw, int $w = 60, int $h = 60): string
+    {
+        $img = imagecreatetruecolor($w, $h);
+        imagefill($img, 0, 0, imagecolorallocate($img, 255, 255, 255));
+        $draw($img);
+        $path = $this->dir . '/' . $name;
+        imagepng($img, $path);
+        imagedestroy($img);
+        return $path;
+    }
+
+    public function testIdenticalImagesScoreHigh(): void
+    {
+        $draw = fn ($img) => imagefilledrectangle($img, 10, 10, 40, 40, imagecolorallocate($img, 0, 0, 0));
+        $this->assertGreaterThanOrEqual(0.99, (new VisualComparator())->compare($this->png('a.png', $draw), $this->png('b.png', $draw)));
+    }
+
+    public function testDifferentImagesScoreLower(): void
+    {
+        $a = $this->png('c.png', fn ($img) => imagefilledrectangle($img, 5, 5, 20, 20, imagecolorallocate($img, 0, 0, 0)));
+        $b = $this->png('d.png', fn ($img) => imagefilledrectangle($img, 35, 35, 55, 55, imagecolorallocate($img, 0, 0, 0)));
+        $this->assertLessThan(0.95, (new VisualComparator())->compare($a, $b));
+    }
+
+    public function testGenerateDiffWritesRedPixels(): void
+    {
+        $a = $this->png('e.png', fn ($img) => null);
+        $b = $this->png('f.png', fn ($img) => imagefilledrectangle($img, 20, 20, 40, 40, imagecolorallocate($img, 0, 0, 0)));
+        $out = $this->dir . '/diff.png';
+        (new VisualComparator())->generateDiff($a, $b, $out);
+        $this->assertFileExists($out);
+        $img = imagecreatefrompng($out);
+        $rgb = imagecolorat($img, 30, 30);
+        $this->assertGreaterThan(150, ($rgb >> 16) & 0xFF);
+        $this->assertLessThan(120, ($rgb >> 8) & 0xFF);
+        imagedestroy($img);
+    }
+}


### PR DESCRIPTION
Ajoute le socle de régression visuelle E2E :
- chemins screenshots references/actual/diff (Screenshots)
- VisualComparator (score similarité 0-1 + image de diff GD)
- VisualReport (HTML autonome base64 + JSON récap)
- JUnitReport : attaches multiples (`$test['attachments']`)
- CommonPage::visualCheckpoint (auto-baseline + comparaison + attaches)
- TestsSuite::$visualResults + Expect::$latestAttachments
- ExecuteSuite : option --visual-report

41 tests unitaires verts. Revue : APPROVE (reset attaches en finally + garde sélecteur introuvable appliqués).

🤖 Generated with [Claude Code](https://claude.com/claude-code)