### PR TITLE
feat(visual): horodatage de génération du rapport

### DIFF
--- a/src/Command/ExecuteSuite.php
+++ b/src/Command/ExecuteSuite.php
@@ -268,8 +268,10 @@ class ExecuteSuite extends Command
         $visualPath = ($visualOption === false) ? null : ($visualOption ?: 'reports/visual/index.html');
         if ($visualPath !== null) {
             $visualReport = new \PrestaFlow\Library\Reports\VisualReport();
-            $this->filePutContents($visualPath, $visualReport->renderHtml(\PrestaFlow\Library\Tests\TestsSuite::$visualResults));
-            $this->filePutContents(dirname($visualPath) . '/visual-results.json', $visualReport->renderJson(\PrestaFlow\Library\Tests\TestsSuite::$visualResults));
+            // Stamp partagé HTML/JSON (une seule lecture de l'horloge).
+            $generatedAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+            $this->filePutContents($visualPath, $visualReport->renderHtml(\PrestaFlow\Library\Tests\TestsSuite::$visualResults, $generatedAt));
+            $this->filePutContents(dirname($visualPath) . '/visual-results.json', $visualReport->renderJson(\PrestaFlow\Library\Tests\TestsSuite::$visualResults, $generatedAt));
             $this->success('Rapport visuel écrit dans ' . $visualPath, newLine: true, force: true);
         }
 

--- a/src/Reports/VisualReport.php
+++ b/src/Reports/VisualReport.php
@@ -4,8 +4,15 @@ namespace PrestaFlow\Library\Reports;
 
 final class VisualReport
 {
-    public function renderHtml(array $results): string
+    /**
+     * @param \DateTimeImmutable|null $generatedAt Horodatage de génération (défaut :
+     *        maintenant, UTC). Injectable pour les tests et pour figer un stamp
+     *        commun entre HTML et JSON.
+     */
+    public function renderHtml(array $results, ?\DateTimeImmutable $generatedAt = null): string
     {
+        $generatedAt ??= new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
         $counts = ['pass' => 0, 'fail' => 0, 'baseline' => 0];
         foreach ($results as $r) { $counts[$r['status']] = ($counts[$r['status']] ?? 0) + 1; }
 
@@ -16,7 +23,8 @@ final class VisualReport
             . '<meta name="viewport" content="width=device-width, initial-scale=1">'
             . '<title>Régression visuelle</title><style>'
             . 'body{font-family:system-ui,sans-serif;margin:2rem;color:#1a1a1a}'
-            . 'h1{font-size:20px}.sum{display:flex;gap:1rem;margin:1rem 0}'
+            . 'h1{font-size:20px;margin:0 0 .25rem}.stamp{color:#666;font-size:13px;margin:0 0 1rem}'
+            . '.sum{display:flex;gap:1rem;margin:1rem 0}'
             . '.card{border:1px solid #e2e2e2;border-radius:10px;padding:1rem;margin:1rem 0}'
             . '.hd{display:flex;justify-content:space-between;align-items:center;margin-bottom:.75rem}'
             . '.badge{font-size:12px;padding:3px 10px;border-radius:6px}'
@@ -26,7 +34,12 @@ final class VisualReport
             . '.imgs figure{margin:0}.imgs img{width:100%;border:1px solid #e2e2e2;border-radius:6px}'
             . '.cap{font-size:12px;color:#666;margin-bottom:4px}</style></head><body>';
 
-        $summary = '<h1>Régression visuelle</h1><div class="sum">'
+        $stampAttr = htmlspecialchars($generatedAt->format(\DateTimeInterface::ATOM), ENT_QUOTES);
+        $stampHuman = htmlspecialchars($generatedAt->format('Y-m-d H:i:s') . ' UTC');
+
+        $summary = '<h1>Régression visuelle</h1>'
+            . '<p class="stamp">Généré le <time datetime="' . $stampAttr . '">' . $stampHuman . '</time></p>'
+            . '<div class="sum">'
             . '<div>Conformes : <strong>' . $counts['pass'] . '</strong></div>'
             . '<div>Écarts : <strong>' . $counts['fail'] . '</strong></div>'
             . '<div>Baselines : <strong>' . $counts['baseline'] . '</strong></div></div>';
@@ -34,11 +47,17 @@ final class VisualReport
         return $head . $summary . $rows . '</body></html>';
     }
 
-    public function renderJson(array $results): string
+    public function renderJson(array $results, ?\DateTimeImmutable $generatedAt = null): string
     {
-        $out = array_map(static fn ($r) => [
-            'name' => $r['name'], 'status' => $r['status'], 'score' => $r['score'],
-        ], $results);
+        $generatedAt ??= new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        $out = [
+            'generatedAt' => $generatedAt->format(\DateTimeInterface::ATOM),
+            'checkpoints' => array_map(static fn ($r) => [
+                'name' => $r['name'], 'status' => $r['status'], 'score' => $r['score'],
+            ], $results),
+        ];
+
         return json_encode($out, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 

--- a/tests/Unit/Reports/VisualReportTest.php
+++ b/tests/Unit/Reports/VisualReportTest.php
@@ -28,13 +28,27 @@ final class VisualReportTest extends TestCase
         $this->assertStringContainsString('baseline', $html);
     }
 
+    public function testHtmlShowsGeneratedAtStamp(): void
+    {
+        $at = new \DateTimeImmutable('2026-07-06T15:30:45', new \DateTimeZone('UTC'));
+        $html = (new VisualReport())->renderHtml([
+            ['name'=>'login','status'=>'pass','score'=>1.0,'threshold'=>0.98,'reference'=>null,'actual'=>null,'diff'=>null],
+        ], $at);
+
+        // Format ISO dans l'attribut datetime + rendu humain lisible dans le texte.
+        $this->assertStringContainsString('datetime="2026-07-06T15:30:45+00:00"', $html);
+        $this->assertStringContainsString('2026-07-06 15:30:45 UTC', $html);
+    }
+
     public function testJsonSummary(): void
     {
+        $at = new \DateTimeImmutable('2026-07-06T15:30:45', new \DateTimeZone('UTC'));
         $json = (new VisualReport())->renderJson([
             ['name'=>'login','status'=>'pass','score'=>0.99,'threshold'=>0.98,'reference'=>null,'actual'=>null,'diff'=>null],
-        ]);
+        ], $at);
         $data = json_decode($json, true);
-        $this->assertSame('login', $data[0]['name']);
-        $this->assertSame('pass', $data[0]['status']);
+        $this->assertSame('2026-07-06T15:30:45+00:00', $data['generatedAt']);
+        $this->assertSame('login', $data['checkpoints'][0]['name']);
+        $this->assertSame('pass', $data['checkpoints'][0]['status']);
     }
 }


### PR DESCRIPTION
HTML : bandeau « Généré le … ». JSON : {generatedAt, checkpoints:[…]} (breaking, consommateurs à mettre à jour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)