### PR TITLE
feat(visual): fuseau configurable pour le stamp du rapport

### DIFF
--- a/src/Command/ExecuteSuite.php
+++ b/src/Command/ExecuteSuite.php
@@ -49,6 +49,7 @@ class ExecuteSuite extends Command
             ->addOption('file', 'f', InputOption::VALUE_NONE, 'Output to file')
             ->addOption('junit', null, InputOption::VALUE_OPTIONAL, 'Write a JUnit XML report (default path: prestaflow/junit.xml)', false)
             ->addOption('visual-report', null, InputOption::VALUE_OPTIONAL, 'Écrit un rapport de régression visuelle (HTML)', false)
+            ->addOption('visual-report-tz', null, InputOption::VALUE_REQUIRED, 'Fuseau horaire du stamp du rapport visuel (ex. Europe/Brussels). Défaut : env PRESTAFLOW_TZ ou UTC.')
             ->addOption('draft', 'd', InputOption::VALUE_NEGATABLE, 'Draft mode')
             ->addArgument('folder', InputArgument::OPTIONAL, 'The folder name', 'tests')
             ->addOption(
@@ -267,9 +268,18 @@ class ExecuteSuite extends Command
         $visualOption = $input->getOption('visual-report');
         $visualPath = ($visualOption === false) ? null : ($visualOption ?: 'reports/visual/index.html');
         if ($visualPath !== null) {
+            // Fuseau du stamp : option CLI > env PRESTAFLOW_TZ > UTC. Fallback UTC
+            // si l'identifiant est invalide (ne casse jamais la génération du rapport).
+            $tzName = $input->getOption('visual-report-tz') ?: ($_ENV['PRESTAFLOW_TZ'] ?? 'UTC');
+            try {
+                $tz = new \DateTimeZone($tzName);
+            } catch (\Exception $e) {
+                $tz = new \DateTimeZone('UTC');
+            }
+
             $visualReport = new \PrestaFlow\Library\Reports\VisualReport();
             // Stamp partagé HTML/JSON (une seule lecture de l'horloge).
-            $generatedAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+            $generatedAt = new \DateTimeImmutable('now', $tz);
             $this->filePutContents($visualPath, $visualReport->renderHtml(\PrestaFlow\Library\Tests\TestsSuite::$visualResults, $generatedAt));
             $this->filePutContents(dirname($visualPath) . '/visual-results.json', $visualReport->renderJson(\PrestaFlow\Library\Tests\TestsSuite::$visualResults, $generatedAt));
             $this->success('Rapport visuel écrit dans ' . $visualPath, newLine: true, force: true);

--- a/src/Reports/VisualReport.php
+++ b/src/Reports/VisualReport.php
@@ -34,8 +34,9 @@ final class VisualReport
             . '.imgs figure{margin:0}.imgs img{width:100%;border:1px solid #e2e2e2;border-radius:6px}'
             . '.cap{font-size:12px;color:#666;margin-bottom:4px}</style></head><body>';
 
+        // `T` = abbréviation du fuseau (CEST/UTC/…). ATOM = ISO 8601 avec offset.
         $stampAttr = htmlspecialchars($generatedAt->format(\DateTimeInterface::ATOM), ENT_QUOTES);
-        $stampHuman = htmlspecialchars($generatedAt->format('Y-m-d H:i:s') . ' UTC');
+        $stampHuman = htmlspecialchars($generatedAt->format('Y-m-d H:i:s T'));
 
         $summary = '<h1>Régression visuelle</h1>'
             . '<p class="stamp">Généré le <time datetime="' . $stampAttr . '">' . $stampHuman . '</time></p>'

--- a/tests/Unit/Reports/VisualReportTest.php
+++ b/tests/Unit/Reports/VisualReportTest.php
@@ -28,16 +28,28 @@ final class VisualReportTest extends TestCase
         $this->assertStringContainsString('baseline', $html);
     }
 
-    public function testHtmlShowsGeneratedAtStamp(): void
+    public function testHtmlShowsGeneratedAtStampInUtc(): void
     {
         $at = new \DateTimeImmutable('2026-07-06T15:30:45', new \DateTimeZone('UTC'));
         $html = (new VisualReport())->renderHtml([
             ['name'=>'login','status'=>'pass','score'=>1.0,'threshold'=>0.98,'reference'=>null,'actual'=>null,'diff'=>null],
         ], $at);
 
-        // Format ISO dans l'attribut datetime + rendu humain lisible dans le texte.
         $this->assertStringContainsString('datetime="2026-07-06T15:30:45+00:00"', $html);
         $this->assertStringContainsString('2026-07-06 15:30:45 UTC', $html);
+    }
+
+    public function testHtmlShowsGeneratedAtStampInLocalTz(): void
+    {
+        // Été → Europe/Brussels = CEST (UTC+2). L'abbréviation doit apparaître
+        // dans le rendu humain, l'ISO doit porter le bon offset.
+        $at = new \DateTimeImmutable('2026-07-06T17:30:45', new \DateTimeZone('Europe/Brussels'));
+        $html = (new VisualReport())->renderHtml([
+            ['name'=>'login','status'=>'pass','score'=>1.0,'threshold'=>0.98,'reference'=>null,'actual'=>null,'diff'=>null],
+        ], $at);
+
+        $this->assertStringContainsString('datetime="2026-07-06T17:30:45+02:00"', $html);
+        $this->assertStringContainsString('2026-07-06 17:30:45 CEST', $html);
     }
 
     public function testJsonSummary(): void


### PR DESCRIPTION
Nouvelle option `--visual-report-tz` (défaut : env `PRESTAFLOW_TZ` ou UTC), avec fallback UTC silencieux si invalide. L'abbréviation du fuseau est affichée dynamiquement (UTC/CEST/…).

🤖 Generated with [Claude Code](https://claude.com/claude-code)