### PR TITLE
fix: réappliquer les en-têtes persistants avant chaque goToUrl()

### DIFF
--- a/src/Pages/CommonPage.php
+++ b/src/Pages/CommonPage.php
@@ -274,6 +274,11 @@ class CommonPage
 
     public function goToUrl(string $url)
     {
+        // Filet : réappliquer les en-têtes persistants (ex. Authorization Basic
+        // Auth) avant chaque navigation. Sans ça, la 1re navigation d'un run peut
+        // partir sans les en-têtes si la page courante n'a jamais été (re)configurée
+        // → 401 → chrome-error://. Idempotent, no-op sans en-têtes définis.
+        \PrestaFlow\Library\Tests\TestsSuite::applyExtraHttpHeaders();
         $this->getPage()->navigate($url)->waitForNavigation();
     }
 


### PR DESCRIPTION
Filet complémentaire à #42. Un goToUrl() sur une page dont l'état d'en-têtes serait incertain partait sans Basic Auth → 401 → chrome-error. Idempotent, no-op sans en-têtes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)