### PR TITLE
refactor: TestsSuite::recreatePage() helper (empêche l'oubli d'applyExtraHttpHeaders)

### DIFF
--- a/src/Pages/FrontOfficePage.php
+++ b/src/Pages/FrontOfficePage.php
@@ -53,10 +53,7 @@ class FrontOfficePage extends CommonPage
         $attempts = 3;
         for ($try = 1; ; $try++) {
             try {
-                TestsSuite::getPage()->close();
-                TestsSuite::getBrowser()->createPage();
-                // Page recréée : réappliquer les en-têtes persistants (ex. Basic Auth).
-                TestsSuite::applyExtraHttpHeaders();
+                TestsSuite::recreatePage();
                 $this->getPage()->navigate($url)->waitForNavigation();
                 break;
             } catch (\Throwable $e) {
@@ -124,16 +121,11 @@ class FrontOfficePage extends CommonPage
 
     public function goToUrl(string $url)
     {
-        // Intentionally overrides CommonPage::goToUrl (a plain navigate) to force
-        // a clean FrontOffice session — recreating the page like goToPage does —
-        // before hitting an absolute FO URL (e.g. a product's canonical preview
-        // URL read from the BackOffice), so BackOffice cookies don't leak in.
-        TestsSuite::getPage()->close();
-        TestsSuite::getBrowser()->createPage();
-        // La page vient d'être recréée : réappliquer les en-têtes persistants
-        // (ex. Authorization Basic Auth) sinon la navigation part sans eux → 401 →
-        // chrome-error://. Identique à ce que goToPage fait déjà.
-        TestsSuite::applyExtraHttpHeaders();
+        // Override intentionnel de CommonPage::goToUrl (simple navigate) : recrée
+        // la page pour partir sur une session FrontOffice propre (utile pour ne
+        // pas hériter des cookies BackOffice) avant d'atteindre une URL absolue.
+        // recreatePage() se charge de réappliquer les en-têtes persistants.
+        TestsSuite::recreatePage();
         $this->getPage()->navigate($url)->waitForNavigation();
     }
 

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -519,6 +519,20 @@ class TestsSuite
     }
 
     /**
+     * Ferme la page courante et en crée une fraîche, en réappliquant les en-têtes
+     * persistants (ex. Authorization Basic Auth). C'est LE point d'entrée pour
+     * démarrer sur une session propre : sans le applyExtraHttpHeaders derrière, la
+     * navigation qui suit part sans en-têtes → 401 → chrome-error://. Idempotent
+     * quant aux en-têtes (no-op si aucun n'est défini).
+     */
+    public static function recreatePage(): void
+    {
+        TestsSuite::getPage()?->close();
+        TestsSuite::getBrowser()?->createPage();
+        TestsSuite::applyExtraHttpHeaders();
+    }
+
+    /**
      * (Ré)applique self::$extraHttpHeaders sur la page courante. À appeler après
      * toute (re)création de page — notamment dans goToPage — car un en-tête posé
      * sur une page fermée est perdu. Best-effort.


### PR DESCRIPTION
Le pattern close+createPage sans applyExtraHttpHeaders derrière a été rencontré 3 fois et a causé plusieurs régressions (401 → chrome-error). Un helper unique `TestsSuite::recreatePage()` fait les 3 étapes et empêche l'oubli à l'avenir.

Refactor pur, aucun changement de comportement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)