### PR TITLE
feat: scrollToAnchor() pour cadrer une capture viewport sur une ancre

### DIFF
--- a/src/Pages/CommonPage.php
+++ b/src/Pages/CommonPage.php
@@ -192,6 +192,30 @@ class CommonPage
     }
 
     /**
+     * Scrolle jusqu'à ce que $selector arrive en haut du viewport. À utiliser
+     * juste avant une capture en mode VIEWPORT (visualCheckpoint sans sélecteur,
+     * $fullPage=false) pour cadrer la capture sur le contenu utile plutôt que
+     * sur le haut de la page (bandeaux promo, cookies, etc.). No-op si le
+     * sélecteur est absent — la lib laisse au projet le soin de garantir la
+     * présence de l'ancre (waitFor, etc.).
+     */
+    public function scrollToAnchor(string $selector, int $settleMs = 400): void
+    {
+        try {
+            $selectorJson = json_encode($selector);
+            $this->getPage()->evaluate(
+                "(function(){"
+                . " var el = document.querySelector($selectorJson);"
+                . " if (el) { el.scrollIntoView({block: 'start'}); }"
+                . "})()"
+            );
+            usleep($settleMs * 1000);
+        } catch (\Throwable $e) {
+            // best-effort : l'écart de capture tranchera si le scroll a échoué
+        }
+    }
+
+    /**
      * Point de contrôle de régression visuelle.
      * - pas de référence => capture-la (auto-baseline), PASS.
      * - référence présente => compare (score >= seuil = PASS, sinon FAIL + attaches actual/diff).


### PR DESCRIPTION
## Résumé

Ajoute `CommonPage::scrollToAnchor(string $selector, int $settleMs = 400)`, un helper best-effort qui scrolle jusqu'à ce que `$selector` arrive en haut du viewport.

## Motivation

Pattern répété dans plusieurs projets qui utilisent le mode **viewport** de `visualCheckpoint` (`$selector = null, $fullPage = false`) : la page est haute, on capture juste la fenêtre pour une taille stable, mais on veut que le haut de la fenêtre soit le contenu métier, pas le header + les bandeaux promo/soldes que le thème pousse en haut de `<main>`.

## Utilisation

```php
$this->frontOfficePage->waitFor('.login-form');   // au projet de garantir la présence
$this->frontOfficePage->scrollToAnchor('.login-form');
$this->frontOfficePage->visualCheckpoint('login', null, 0.98, false);
```

## Choix de design

- **Best-effort** : `try/catch` autour du `evaluate`, no-op si l'ancre est absente. La lib ne connaît pas le DOM du projet ; c'est au projet de garantir la présence via `waitFor` avant l'appel.
- **API séparée** plutôt qu'une option de `visualCheckpoint($anchor: …)`: le scroll est une préoccupation distincte de la capture. Rétrocompatible.
- **`json_encode` du sélecteur** : accepte les sélecteurs avec quotes.