### PR TITLE
feat(results): aggregate suites + source location for CI

### DIFF
--- a/src/Command/ExecuteSuite.php
+++ b/src/Command/ExecuteSuite.php
@@ -39,6 +39,8 @@ class ExecuteSuite extends Command
 
     protected $file = 'prestaflow/results.json';
 
+    protected array $aggregatedSuites = [];
+
     use Output;
 
     protected function configure(): void
@@ -225,8 +227,7 @@ class ExecuteSuite extends Command
 
                     if (self::OUTPUT_JSON === $this->getOutputMode()) {
                         if ($input->getOption('file')) {
-                            $this->filePutContents($this->file, json_encode($suite->results(false), JSON_PRETTY_PRINT));
-                            $this->success('Results saved to ' . $this->file, newLine: true, force: true);
+                            $this->aggregatedSuites[] = $suite->results(false);
                         } else {
                             $this->output->writeLn(json_encode($suite->results(false), JSON_PRETTY_PRINT));
                         }
@@ -243,6 +244,14 @@ class ExecuteSuite extends Command
 
         $this->sections['progressIndicator']->finish('Finished');
         $this->sections['progressBar']->clear();
+
+        if ($input->getOption('file') && self::OUTPUT_JSON === $this->getOutputMode()) {
+            $this->filePutContents(
+                $this->file,
+                json_encode(['suites' => $this->aggregatedSuites], JSON_PRETTY_PRINT)
+            );
+            $this->success('Results saved to ' . $this->file, newLine: true, force: true);
+        }
 
         if (!$nbSuites) {
             $this->success('Tests folder is empty', newLine: true);

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -164,10 +164,13 @@ class TestsSuite
 
     public function it(string $description, Closure $steps)
     {
+        $reflection = new \ReflectionFunction($steps);
         $this->tests[] = [
             'title' => $description,
             'steps' => $steps,
             'datasets' => $this->datasets,
+            'file' => $reflection->getFileName(),
+            'line' => $reflection->getStartLine(),
         ];
 
         return $this;
@@ -175,10 +178,13 @@ class TestsSuite
 
     public function skip(string $description, Closure $steps)
     {
+        $reflection = new \ReflectionFunction($steps);
         $this->tests[] = [
             'title' => $description,
             'steps' => $steps,
             'skip' => true,
+            'file' => $reflection->getFileName(),
+            'line' => $reflection->getStartLine(),
         ];
 
         return $this;
@@ -186,10 +192,13 @@ class TestsSuite
 
     public function todo(string $description, Closure $steps)
     {
+        $reflection = new \ReflectionFunction($steps);
         $this->tests[] = [
             'title' => $description,
             'steps' => $steps,
             'todo' => true,
+            'file' => $reflection->getFileName(),
+            'line' => $reflection->getStartLine(),
         ];
 
         return $this;


### PR DESCRIPTION
## Summary
- **TestsSuite**: `it()`, `skip()`, `todo()` now capture the closure's source file and line via `ReflectionFunction` and store them in each test entry. Enables CI to point at the test source in PR comments.
- **ExecuteSuite**: when `--file` is used with JSON output, per-suite results were being written to the same path (each suite overwrote the previous). Now results are accumulated and written once after the loop as `{ "suites": [...] }`.

## Motivation
Required by the new PrestaFlow GitHub Action v2 to:
- Handle projects with multiple test suites correctly.
- Show failure source location in the PR comment.

## Breaking changes
Yes — the shape of `prestaflow/results.json` when produced by `--file` changes from a single suite object to `{ "suites": [ ... ] }`. Consumers reading the file need to iterate the new envelope. The v1 GitHub Action uploads this file to the API as-is, so the API side may need a matching update.

## Test plan
- [ ] `php -l` on both modified files.
- [ ] `composer tests` on a project using this library and running `prestaflow:json:file` — verify `prestaflow/results.json` contains all suites and each failing test includes `file` + `line`.
- [ ] Confirm non-JSON output modes (full, compact) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)