### PR TITLE
fix + feat: browser cache in temp dir, persistent headers, scrollToAnchor

### DIFF
--- a/src/Command/ExecuteSuite.php
+++ b/src/Command/ExecuteSuite.php
@@ -270,7 +270,11 @@ class ExecuteSuite extends Command
         if ($visualPath !== null) {
             // Fuseau du stamp : option CLI > env PRESTAFLOW_TZ > UTC. Fallback UTC
             // si l'identifiant est invalide (ne casse jamais la génération du rapport).
-            $tzName = $input->getOption('visual-report-tz') ?: ($_ENV['PRESTAFLOW_TZ'] ?? 'UTC');
+            // On lit à la fois $_ENV et getenv() : selon variables_order de PHP,
+            // seul l'un ou l'autre peut être peuplé par le shell parent (setup-php CI
+            // ne peuple pas $_ENV par défaut).
+            $tzName = $input->getOption('visual-report-tz')
+                ?: ($_ENV['PRESTAFLOW_TZ'] ?? getenv('PRESTAFLOW_TZ') ?: 'UTC');
             try {
                 $tz = new \DateTimeZone($tzName);
             } catch (\Exception $e) {

--- a/src/Command/ExecuteSuite.php
+++ b/src/Command/ExecuteSuite.php
@@ -268,8 +268,10 @@ class ExecuteSuite extends Command
         $visualPath = ($visualOption === false) ? null : ($visualOption ?: 'reports/visual/index.html');
         if ($visualPath !== null) {
             $visualReport = new \PrestaFlow\Library\Reports\VisualReport();
-            $this->filePutContents($visualPath, $visualReport->renderHtml(\PrestaFlow\Library\Tests\TestsSuite::$visualResults));
-            $this->filePutContents(dirname($visualPath) . '/visual-results.json', $visualReport->renderJson(\PrestaFlow\Library\Tests\TestsSuite::$visualResults));
+            // Stamp partagé HTML/JSON (une seule lecture de l'horloge).
+            $generatedAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+            $this->filePutContents($visualPath, $visualReport->renderHtml(\PrestaFlow\Library\Tests\TestsSuite::$visualResults, $generatedAt));
+            $this->filePutContents(dirname($visualPath) . '/visual-results.json', $visualReport->renderJson(\PrestaFlow\Library\Tests\TestsSuite::$visualResults, $generatedAt));
             $this->success('Rapport visuel écrit dans ' . $visualPath, newLine: true, force: true);
         }
 

--- a/src/Command/ExecuteSuite.php
+++ b/src/Command/ExecuteSuite.php
@@ -49,6 +49,7 @@ class ExecuteSuite extends Command
             ->addOption('file', 'f', InputOption::VALUE_NONE, 'Output to file')
             ->addOption('junit', null, InputOption::VALUE_OPTIONAL, 'Write a JUnit XML report (default path: prestaflow/junit.xml)', false)
             ->addOption('visual-report', null, InputOption::VALUE_OPTIONAL, 'Écrit un rapport de régression visuelle (HTML)', false)
+            ->addOption('visual-report-tz', null, InputOption::VALUE_REQUIRED, 'Fuseau horaire du stamp du rapport visuel (ex. Europe/Brussels). Défaut : env PRESTAFLOW_TZ ou UTC.')
             ->addOption('draft', 'd', InputOption::VALUE_NEGATABLE, 'Draft mode')
             ->addArgument('folder', InputArgument::OPTIONAL, 'The folder name', 'tests')
             ->addOption(
@@ -267,9 +268,18 @@ class ExecuteSuite extends Command
         $visualOption = $input->getOption('visual-report');
         $visualPath = ($visualOption === false) ? null : ($visualOption ?: 'reports/visual/index.html');
         if ($visualPath !== null) {
+            // Fuseau du stamp : option CLI > env PRESTAFLOW_TZ > UTC. Fallback UTC
+            // si l'identifiant est invalide (ne casse jamais la génération du rapport).
+            $tzName = $input->getOption('visual-report-tz') ?: ($_ENV['PRESTAFLOW_TZ'] ?? 'UTC');
+            try {
+                $tz = new \DateTimeZone($tzName);
+            } catch (\Exception $e) {
+                $tz = new \DateTimeZone('UTC');
+            }
+
             $visualReport = new \PrestaFlow\Library\Reports\VisualReport();
             // Stamp partagé HTML/JSON (une seule lecture de l'horloge).
-            $generatedAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+            $generatedAt = new \DateTimeImmutable('now', $tz);
             $this->filePutContents($visualPath, $visualReport->renderHtml(\PrestaFlow\Library\Tests\TestsSuite::$visualResults, $generatedAt));
             $this->filePutContents(dirname($visualPath) . '/visual-results.json', $visualReport->renderJson(\PrestaFlow\Library\Tests\TestsSuite::$visualResults, $generatedAt));
             $this->success('Rapport visuel écrit dans ' . $visualPath, newLine: true, force: true);

--- a/src/Command/ExecuteSuite.php
+++ b/src/Command/ExecuteSuite.php
@@ -293,8 +293,8 @@ class ExecuteSuite extends Command
             \PrestaFlow\Library\Tests\TestsSuite::getBrowser(force: false)?->close();
         } catch (\Throwable $e) {
         }
-        @unlink(\PrestaFlow\Library\Tests\TestsSuite::getFilePath('.broswer'));
-        @unlink(\PrestaFlow\Library\Tests\TestsSuite::getFilePath('.broswer-options'));
+        @unlink(\PrestaFlow\Library\Tests\TestsSuite::getFilePath('.browser'));
+        @unlink(\PrestaFlow\Library\Tests\TestsSuite::getFilePath('.browser-options'));
 
         return $summary->hasFailures() ? Command::FAILURE : Command::SUCCESS;
     }

--- a/src/Pages/CommonPage.php
+++ b/src/Pages/CommonPage.php
@@ -192,6 +192,30 @@ class CommonPage
     }
 
     /**
+     * Scrolle jusqu'à ce que $selector arrive en haut du viewport. À utiliser
+     * juste avant une capture en mode VIEWPORT (visualCheckpoint sans sélecteur,
+     * $fullPage=false) pour cadrer la capture sur le contenu utile plutôt que
+     * sur le haut de la page (bandeaux promo, cookies, etc.). No-op si le
+     * sélecteur est absent — la lib laisse au projet le soin de garantir la
+     * présence de l'ancre (waitFor, etc.).
+     */
+    public function scrollToAnchor(string $selector, int $settleMs = 400): void
+    {
+        try {
+            $selectorJson = json_encode($selector);
+            $this->getPage()->evaluate(
+                "(function(){"
+                . " var el = document.querySelector($selectorJson);"
+                . " if (el) { el.scrollIntoView({block: 'start'}); }"
+                . "})()"
+            );
+            usleep($settleMs * 1000);
+        } catch (\Throwable $e) {
+            // best-effort : l'écart de capture tranchera si le scroll a échoué
+        }
+    }
+
+    /**
      * Point de contrôle de régression visuelle.
      * - pas de référence => capture-la (auto-baseline), PASS.
      * - référence présente => compare (score >= seuil = PASS, sinon FAIL + attaches actual/diff).

--- a/src/Pages/CommonPage.php
+++ b/src/Pages/CommonPage.php
@@ -274,6 +274,11 @@ class CommonPage
 
     public function goToUrl(string $url)
     {
+        // Filet : réappliquer les en-têtes persistants (ex. Authorization Basic
+        // Auth) avant chaque navigation. Sans ça, la 1re navigation d'un run peut
+        // partir sans les en-têtes si la page courante n'a jamais été (re)configurée
+        // → 401 → chrome-error://. Idempotent, no-op sans en-têtes définis.
+        \PrestaFlow\Library\Tests\TestsSuite::applyExtraHttpHeaders();
         $this->getPage()->navigate($url)->waitForNavigation();
     }
 

--- a/src/Pages/FrontOfficePage.php
+++ b/src/Pages/FrontOfficePage.php
@@ -53,10 +53,7 @@ class FrontOfficePage extends CommonPage
         $attempts = 3;
         for ($try = 1; ; $try++) {
             try {
-                TestsSuite::getPage()->close();
-                TestsSuite::getBrowser()->createPage();
-                // Page recréée : réappliquer les en-têtes persistants (ex. Basic Auth).
-                TestsSuite::applyExtraHttpHeaders();
+                TestsSuite::recreatePage();
                 $this->getPage()->navigate($url)->waitForNavigation();
                 break;
             } catch (\Throwable $e) {
@@ -124,16 +121,11 @@ class FrontOfficePage extends CommonPage
 
     public function goToUrl(string $url)
     {
-        // Intentionally overrides CommonPage::goToUrl (a plain navigate) to force
-        // a clean FrontOffice session — recreating the page like goToPage does —
-        // before hitting an absolute FO URL (e.g. a product's canonical preview
-        // URL read from the BackOffice), so BackOffice cookies don't leak in.
-        TestsSuite::getPage()->close();
-        TestsSuite::getBrowser()->createPage();
-        // La page vient d'être recréée : réappliquer les en-têtes persistants
-        // (ex. Authorization Basic Auth) sinon la navigation part sans eux → 401 →
-        // chrome-error://. Identique à ce que goToPage fait déjà.
-        TestsSuite::applyExtraHttpHeaders();
+        // Override intentionnel de CommonPage::goToUrl (simple navigate) : recrée
+        // la page pour partir sur une session FrontOffice propre (utile pour ne
+        // pas hériter des cookies BackOffice) avant d'atteindre une URL absolue.
+        // recreatePage() se charge de réappliquer les en-têtes persistants.
+        TestsSuite::recreatePage();
         $this->getPage()->navigate($url)->waitForNavigation();
     }
 

--- a/src/Pages/FrontOfficePage.php
+++ b/src/Pages/FrontOfficePage.php
@@ -130,6 +130,10 @@ class FrontOfficePage extends CommonPage
         // URL read from the BackOffice), so BackOffice cookies don't leak in.
         TestsSuite::getPage()->close();
         TestsSuite::getBrowser()->createPage();
+        // La page vient d'être recréée : réappliquer les en-têtes persistants
+        // (ex. Authorization Basic Auth) sinon la navigation part sans eux → 401 →
+        // chrome-error://. Identique à ce que goToPage fait déjà.
+        TestsSuite::applyExtraHttpHeaders();
         $this->getPage()->navigate($url)->waitForNavigation();
     }
 

--- a/src/Reports/VisualReport.php
+++ b/src/Reports/VisualReport.php
@@ -34,8 +34,9 @@ final class VisualReport
             . '.imgs figure{margin:0}.imgs img{width:100%;border:1px solid #e2e2e2;border-radius:6px}'
             . '.cap{font-size:12px;color:#666;margin-bottom:4px}</style></head><body>';
 
+        // `T` = abbréviation du fuseau (CEST/UTC/…). ATOM = ISO 8601 avec offset.
         $stampAttr = htmlspecialchars($generatedAt->format(\DateTimeInterface::ATOM), ENT_QUOTES);
-        $stampHuman = htmlspecialchars($generatedAt->format('Y-m-d H:i:s') . ' UTC');
+        $stampHuman = htmlspecialchars($generatedAt->format('Y-m-d H:i:s T'));
 
         $summary = '<h1>Régression visuelle</h1>'
             . '<p class="stamp">Généré le <time datetime="' . $stampAttr . '">' . $stampHuman . '</time></p>'

--- a/src/Reports/VisualReport.php
+++ b/src/Reports/VisualReport.php
@@ -4,8 +4,15 @@ namespace PrestaFlow\Library\Reports;
 
 final class VisualReport
 {
-    public function renderHtml(array $results): string
+    /**
+     * @param \DateTimeImmutable|null $generatedAt Horodatage de génération (défaut :
+     *        maintenant, UTC). Injectable pour les tests et pour figer un stamp
+     *        commun entre HTML et JSON.
+     */
+    public function renderHtml(array $results, ?\DateTimeImmutable $generatedAt = null): string
     {
+        $generatedAt ??= new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
         $counts = ['pass' => 0, 'fail' => 0, 'baseline' => 0];
         foreach ($results as $r) { $counts[$r['status']] = ($counts[$r['status']] ?? 0) + 1; }
 
@@ -16,7 +23,8 @@ final class VisualReport
             . '<meta name="viewport" content="width=device-width, initial-scale=1">'
             . '<title>Régression visuelle</title><style>'
             . 'body{font-family:system-ui,sans-serif;margin:2rem;color:#1a1a1a}'
-            . 'h1{font-size:20px}.sum{display:flex;gap:1rem;margin:1rem 0}'
+            . 'h1{font-size:20px;margin:0 0 .25rem}.stamp{color:#666;font-size:13px;margin:0 0 1rem}'
+            . '.sum{display:flex;gap:1rem;margin:1rem 0}'
             . '.card{border:1px solid #e2e2e2;border-radius:10px;padding:1rem;margin:1rem 0}'
             . '.hd{display:flex;justify-content:space-between;align-items:center;margin-bottom:.75rem}'
             . '.badge{font-size:12px;padding:3px 10px;border-radius:6px}'
@@ -26,7 +34,12 @@ final class VisualReport
             . '.imgs figure{margin:0}.imgs img{width:100%;border:1px solid #e2e2e2;border-radius:6px}'
             . '.cap{font-size:12px;color:#666;margin-bottom:4px}</style></head><body>';
 
-        $summary = '<h1>Régression visuelle</h1><div class="sum">'
+        $stampAttr = htmlspecialchars($generatedAt->format(\DateTimeInterface::ATOM), ENT_QUOTES);
+        $stampHuman = htmlspecialchars($generatedAt->format('Y-m-d H:i:s') . ' UTC');
+
+        $summary = '<h1>Régression visuelle</h1>'
+            . '<p class="stamp">Généré le <time datetime="' . $stampAttr . '">' . $stampHuman . '</time></p>'
+            . '<div class="sum">'
             . '<div>Conformes : <strong>' . $counts['pass'] . '</strong></div>'
             . '<div>Écarts : <strong>' . $counts['fail'] . '</strong></div>'
             . '<div>Baselines : <strong>' . $counts['baseline'] . '</strong></div></div>';
@@ -34,11 +47,17 @@ final class VisualReport
         return $head . $summary . $rows . '</body></html>';
     }
 
-    public function renderJson(array $results): string
+    public function renderJson(array $results, ?\DateTimeImmutable $generatedAt = null): string
     {
-        $out = array_map(static fn ($r) => [
-            'name' => $r['name'], 'status' => $r['status'], 'score' => $r['score'],
-        ], $results);
+        $generatedAt ??= new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        $out = [
+            'generatedAt' => $generatedAt->format(\DateTimeInterface::ATOM),
+            'checkpoints' => array_map(static fn ($r) => [
+                'name' => $r['name'], 'status' => $r['status'], 'score' => $r['score'],
+            ], $results),
+        ];
+
         return json_encode($out, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 

--- a/src/Reports/VisualReport.php
+++ b/src/Reports/VisualReport.php
@@ -24,15 +24,16 @@ final class VisualReport
             . '<title>Régression visuelle</title><style>'
             . 'body{font-family:system-ui,sans-serif;margin:2rem;color:#1a1a1a}'
             . 'h1{font-size:20px;margin:0 0 .25rem}.stamp{color:#666;font-size:13px;margin:0 0 1rem}'
-            . '.sum{display:flex;gap:1rem;margin:1rem 0}'
+            . '.sum{display:flex;flex-wrap:wrap;gap:.5rem;margin:1rem 0}'
             . '.card{border:1px solid #e2e2e2;border-radius:10px;padding:1rem;margin:1rem 0}'
-            . '.hd{display:flex;justify-content:space-between;align-items:center;margin-bottom:.75rem}'
+            . '.hd{display:flex;flex-wrap:wrap;gap:.5rem;justify-content:space-between;align-items:center;margin-bottom:.75rem}'
             . '.badge{font-size:12px;padding:3px 10px;border-radius:6px}'
             . '.pass{background:#e1f5ee;color:#0f6e56}.fail{background:#fceceb;color:#a32d2d}'
             . '.baseline{background:#e6f1fb;color:#0c447c}'
-            . '.imgs{display:grid;grid-template-columns:repeat(3,1fr);gap:.75rem}'
-            . '.imgs figure{margin:0}.imgs img{width:100%;border:1px solid #e2e2e2;border-radius:6px}'
-            . '.cap{font-size:12px;color:#666;margin-bottom:4px}</style></head><body>';
+            . '.imgs{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:.75rem}'
+            . '.imgs figure{margin:0;min-width:0}.imgs img{width:100%;height:auto;border:1px solid #e2e2e2;border-radius:6px;display:block}'
+            . '.cap{font-size:12px;color:#666;margin-bottom:4px}'
+            . '@media (max-width:640px){body{margin:1rem}.card{padding:.75rem}h1{font-size:18px}}</style></head><body>';
 
         // `T` = abbréviation du fuseau (CEST/UTC/…). ATOM = ISO 8601 avec offset.
         $stampAttr = htmlspecialchars($generatedAt->format(\DateTimeInterface::ATOM), ENT_QUOTES);

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -519,6 +519,20 @@ class TestsSuite
     }
 
     /**
+     * Ferme la page courante et en crée une fraîche, en réappliquant les en-têtes
+     * persistants (ex. Authorization Basic Auth). C'est LE point d'entrée pour
+     * démarrer sur une session propre : sans le applyExtraHttpHeaders derrière, la
+     * navigation qui suit part sans en-têtes → 401 → chrome-error://. Idempotent
+     * quant aux en-têtes (no-op si aucun n'est défini).
+     */
+    public static function recreatePage(): void
+    {
+        TestsSuite::getPage()?->close();
+        TestsSuite::getBrowser()?->createPage();
+        TestsSuite::applyExtraHttpHeaders();
+    }
+
+    /**
      * (Ré)applique self::$extraHttpHeaders sur la page courante. À appeler après
      * toute (re)création de page — notamment dans goToPage — car un en-tête posé
      * sur une page fermée est perdu. Best-effort.

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -243,15 +243,17 @@ class TestsSuite
         return $this->groups;
     }
 
-    public static function getFilePath($filename = '.broswer')
+    public static function getFilePath($filename = '.browser')
     {
         if (function_exists('storage_path')) {
-            $filePath = storage_path().'/datas/'.$filename;
-        } else {
-            $filePath = __DIR__.'/../../datas/'.$filename;
+            $dir = storage_path().'/datas';
+            if (!is_dir($dir)) {
+                @mkdir($dir, 0777, true);
+            }
+            return $dir.'/'.$filename;
         }
 
-        return $filePath;
+        return sys_get_temp_dir().'/prestaflow-'.$filename;
     }
 
 
@@ -276,8 +278,8 @@ class TestsSuite
             'headless' => (bool) $headless,
         ];
 
-        $browserOptionsFile = TestsSuite::getFilePath('.broswer-options');
-        $socketFile = TestsSuite::getFilePath('.broswer');
+        $browserOptionsFile = TestsSuite::getFilePath('.browser-options');
+        $socketFile = TestsSuite::getFilePath('.browser');
 
         $socket = null;
         if (file_exists($browserOptionsFile)) {
@@ -327,20 +329,14 @@ class TestsSuite
 
     public static function getSocketFilePath()
     {
-        if (function_exists('storage_path')) {
-            $socketFilePath = storage_path().'/datas/.broswer';
-        } else {
-            $socketFilePath = __DIR__.'/../../datas/.broswer';
-        }
-
-        return $socketFilePath;
+        return self::getFilePath('.browser');
     }
 
     public static function getBrowser(bool $headless = true, bool $force = true)
     {
         $browser = null;
 
-        $socketFile = TestsSuite::getFilePath('.broswer');
+        $socketFile = TestsSuite::getFilePath('.browser');
 
         $socket = null;
         if (file_exists($socketFile)) {

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -450,29 +450,31 @@ class TestsSuite
 
         TestsSuite::getBrowser(headless: $headless, force: true);
 
-        // Authentification HTTP Basic (env) posée en header sur TOUTES les requêtes
-        // (navigation top-level, sous-ressources ET XHR), avant toute navigation.
-        // Plus fiable que des identifiants dans l'URL (https://user:pass@host/…),
-        // que Chrome n'applique pas aux requêtes XHR ni toujours aux redirections.
-        $this->presetBasicAuth();
-
-        // Pré-réglage de cookies fournis via l'environnement (PRESTAFLOW_COOKIES,
-        // JSON), avant toute navigation. Pratique pour neutraliser un bandeau de
-        // consentement (RGPD) sur un environnement protégé/preprod.
-        $this->presetEnvCookies();
-
+        // 1) Nettoyer les cookies héritées de la suite précédente. Cet appel doit
+        //    précéder presetEnvCookies() : sinon il EFFACE les cookies qu'on vient
+        //    tout juste de poser (ex. ___kbgdcc pour neutraliser un bandeau RGPD →
+        //    le bandeau ré-apparaît, un « h1 » générique attrape « Centre de
+        //    paramètres des cookies » et les tests plantent).
         try {
             $page = TestsSuite::getPage();
             if ($page !== null) {
-                // Clear all browser cookies so each suite starts from a clean,
-                // unauthenticated state (the previous per-cookie clearing set a
-                // malformed expiry and never actually removed the admin session).
                 $page->getSession()->sendMessageSync(
                     new \HeadlessChromium\Communication\Message('Network.clearBrowserCookies')
                 );
             }
         } catch (\Throwable $e) {
         }
+
+        // 2) Authentification HTTP Basic (env) posée en header sur TOUTES les
+        // requêtes (navigation top-level, sous-ressources ET XHR), avant toute
+        // navigation. Plus fiable que des identifiants dans l'URL, que Chrome
+        // n'applique pas aux requêtes XHR ni toujours aux redirections.
+        $this->presetBasicAuth();
+
+        // 3) Pré-réglage de cookies fournis via l'environnement (PRESTAFLOW_COOKIES,
+        // JSON), avant toute navigation. Pratique pour neutraliser un bandeau de
+        // consentement (RGPD) sur un environnement protégé/preprod.
+        $this->presetEnvCookies();
 
         $this->start_time = hrtime(true);
     }

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -364,10 +364,20 @@ class TestsSuite
                 return null;
             }
 
+            // Dimensions de la fenêtre : PRESTAFLOW_WINDOW_SIZE_WIDTH/HEIGHT en
+            // env (utile pour émuler mobile/tablet/desktop). Défaut FHD 1920×1080.
+            // On lit à la fois $_ENV et getenv() : selon variables_order de PHP,
+            // seul l'un ou l'autre peut être peuplé par le shell parent (setup-php
+            // CI ne peuple pas $_ENV par défaut).
+            $envWidth  = $_ENV['PRESTAFLOW_WINDOW_SIZE_WIDTH']  ?? getenv('PRESTAFLOW_WINDOW_SIZE_WIDTH');
+            $envHeight = $_ENV['PRESTAFLOW_WINDOW_SIZE_HEIGHT'] ?? getenv('PRESTAFLOW_WINDOW_SIZE_HEIGHT');
+            $winWidth  = (int) ($envWidth  ?: 1920);
+            $winHeight = (int) ($envHeight ?: 1080);
+
             $options = [
-                'userAgent' => $_ENV['PRESTAFLOW_USER_AGENT'] ?? 'PrestaFlow',
+                'userAgent' => $_ENV['PRESTAFLOW_USER_AGENT'] ?? getenv('PRESTAFLOW_USER_AGENT') ?: 'PrestaFlow',
                 'keepAlive' => true,
-                'windowSize' => [1920, 1000],
+                'windowSize' => [$winWidth, $winHeight],
                 'headless' => (bool) $headless,
                 'ignoreCertificateErrors' => true,
             ];

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -406,9 +406,21 @@ class TestsSuite
         for ($try = 1; ; $try++) {
             try {
                 $pages = TestsSuite::getBrowser()?->getPages();
+                $createdNew = false;
                 if (count($pages) == 0) {
                     TestsSuite::getBrowser()?->createPage();
+                    $createdNew = true;
                 }
+
+                // Si on vient de créer la page (aucune n'existait), les en-têtes
+                // persistants (ex. Authorization Basic Auth) doivent y être appliqués
+                // AVANT que le consommateur n'y navigue. Sans ça, un goToUrl() ferait
+                // sa navigation sans Basic Auth → 401 → chrome-error. Les chemins
+                // via goToPage font déjà applyExtraHttpHeaders eux-mêmes.
+                if ($createdNew) {
+                    TestsSuite::applyExtraHttpHeaders();
+                }
+
                 return TestsSuite::getBrowser()?->getPages()[0];
             } catch (\Throwable $e) {
                 if ($try >= 3) {

--- a/src/Traits/AppVersion.php
+++ b/src/Traits/AppVersion.php
@@ -4,5 +4,5 @@ namespace PrestaFlow\Library\Traits;
 
 class AppVersion
 {
-    const APP_VERSION = '1.4.0';
+    const APP_VERSION = '1.5.0';
 }

--- a/tests/Unit/Reports/VisualReportTest.php
+++ b/tests/Unit/Reports/VisualReportTest.php
@@ -28,13 +28,27 @@ final class VisualReportTest extends TestCase
         $this->assertStringContainsString('baseline', $html);
     }
 
+    public function testHtmlShowsGeneratedAtStamp(): void
+    {
+        $at = new \DateTimeImmutable('2026-07-06T15:30:45', new \DateTimeZone('UTC'));
+        $html = (new VisualReport())->renderHtml([
+            ['name'=>'login','status'=>'pass','score'=>1.0,'threshold'=>0.98,'reference'=>null,'actual'=>null,'diff'=>null],
+        ], $at);
+
+        // Format ISO dans l'attribut datetime + rendu humain lisible dans le texte.
+        $this->assertStringContainsString('datetime="2026-07-06T15:30:45+00:00"', $html);
+        $this->assertStringContainsString('2026-07-06 15:30:45 UTC', $html);
+    }
+
     public function testJsonSummary(): void
     {
+        $at = new \DateTimeImmutable('2026-07-06T15:30:45', new \DateTimeZone('UTC'));
         $json = (new VisualReport())->renderJson([
             ['name'=>'login','status'=>'pass','score'=>0.99,'threshold'=>0.98,'reference'=>null,'actual'=>null,'diff'=>null],
-        ]);
+        ], $at);
         $data = json_decode($json, true);
-        $this->assertSame('login', $data[0]['name']);
-        $this->assertSame('pass', $data[0]['status']);
+        $this->assertSame('2026-07-06T15:30:45+00:00', $data['generatedAt']);
+        $this->assertSame('login', $data['checkpoints'][0]['name']);
+        $this->assertSame('pass', $data['checkpoints'][0]['status']);
     }
 }

--- a/tests/Unit/Reports/VisualReportTest.php
+++ b/tests/Unit/Reports/VisualReportTest.php
@@ -28,16 +28,28 @@ final class VisualReportTest extends TestCase
         $this->assertStringContainsString('baseline', $html);
     }
 
-    public function testHtmlShowsGeneratedAtStamp(): void
+    public function testHtmlShowsGeneratedAtStampInUtc(): void
     {
         $at = new \DateTimeImmutable('2026-07-06T15:30:45', new \DateTimeZone('UTC'));
         $html = (new VisualReport())->renderHtml([
             ['name'=>'login','status'=>'pass','score'=>1.0,'threshold'=>0.98,'reference'=>null,'actual'=>null,'diff'=>null],
         ], $at);
 
-        // Format ISO dans l'attribut datetime + rendu humain lisible dans le texte.
         $this->assertStringContainsString('datetime="2026-07-06T15:30:45+00:00"', $html);
         $this->assertStringContainsString('2026-07-06 15:30:45 UTC', $html);
+    }
+
+    public function testHtmlShowsGeneratedAtStampInLocalTz(): void
+    {
+        // Été → Europe/Brussels = CEST (UTC+2). L'abbréviation doit apparaître
+        // dans le rendu humain, l'ISO doit porter le bon offset.
+        $at = new \DateTimeImmutable('2026-07-06T17:30:45', new \DateTimeZone('Europe/Brussels'));
+        $html = (new VisualReport())->renderHtml([
+            ['name'=>'login','status'=>'pass','score'=>1.0,'threshold'=>0.98,'reference'=>null,'actual'=>null,'diff'=>null],
+        ], $at);
+
+        $this->assertStringContainsString('datetime="2026-07-06T17:30:45+02:00"', $html);
+        $this->assertStringContainsString('2026-07-06 17:30:45 CEST', $html);
     }
 
     public function testJsonSummary(): void


### PR DESCRIPTION
## Summary

Batch of 9 accumulated commits — merging into `dev`.

## Highlights

- **6a2526e — fix(TestsSuite)**: store browser cache in `sys_get_temp_dir()` (prefixed `prestaflow-`) when `storage_path()` is unavailable, and create the `datas/` fallback dir. Also renames `.broswer` → `.browser` (long-standing typo). Fixes runtime `file_put_contents: Failed to open stream` warnings when installed via composer (no `datas/` shipped).
- 7cbfa6e — feat: `CommonPage::scrollToAnchor()` to frame viewport captures on an anchor.
- f7e765c — fix: `getBrowser` reads `PRESTAFLOW_WINDOW_SIZE_WIDTH/HEIGHT` and `USER_AGENT` from env.
- 6bcd675 — refactor: `TestsSuite::recreatePage()` helper.
- ca9172a / ae41527 / d4e6df6 — persistent headers reliability across implicit page recreations and `goToUrl()`.
- 627fefa — fix: clear cookies BEFORE `presetEnvCookies` (preserve the preset cookie).
- ab865da — fix(VisualReport): mobile responsive HTML layout (also on `main` via #49, harmless duplicate).
- 6089f56 — Bump AppVersion to 1.5.0.

## Why now

The browser-cache fix is required by [PrestaFlow/github-action-smoke](https://github.com/PrestaFlow/github-action-smoke) — without it, every CI run raises a PHP warning that makes composer exit non-zero, masking the action's reporting.

## Test plan

- [ ] `composer test-unit` passes on the merge commit.
- [ ] Re-run the smoke workflow and verify no more `Failed to open stream` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)