### PR TITLE
feat(visual): Lot 3 — tag support + visual[] block in results.json

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,5 +8,8 @@
         <testsuite name="Unit">
             <directory>tests/Unit</directory>
         </testsuite>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Pages/CommonPage.php
+++ b/src/Pages/CommonPage.php
@@ -216,6 +216,34 @@ class CommonPage
     }
 
     /**
+     * Best-effort : dimensions du viewport courant via le navigateur. `null`
+     * pour un des deux (ou les deux) si l'info n'est pas disponible (page
+     * absente, evaluate en échec, etc.) — VisualTag::resolve() sait gérer
+     * les segments manquants avec un placeholder `?`.
+     *
+     * @return array{0: ?int, 1: ?int} [width, height]
+     */
+    private function getViewportSize(): array
+    {
+        try {
+            $value = $this->getPage()->evaluate(
+                '(function(){return [window.innerWidth, window.innerHeight];})()'
+            )->getReturnValue();
+
+            if (is_array($value) && count($value) === 2) {
+                return [
+                    $value[0] !== null ? (int) $value[0] : null,
+                    $value[1] !== null ? (int) $value[1] : null,
+                ];
+            }
+        } catch (\Throwable $e) {
+            // best-effort : le tag auto retombera sur des placeholders `?`
+        }
+
+        return [null, null];
+    }
+
+    /**
      * Point de contrôle de régression visuelle.
      * - pas de référence => capture-la (auto-baseline), PASS.
      * - référence présente => compare (score >= seuil = PASS, sinon FAIL + attaches actual/diff).
@@ -226,10 +254,31 @@ class CommonPage
      * - $selector null && $fullPage=false => VIEWPORT seul (hauteur fixe de la
      *   fenêtre). À utiliser pour les pages HAUTES à contenu lazy dont la hauteur
      *   pleine page varie selon l'état de chargement (faux écarts).
+     *
+     * $tag : identifiant de baseline `(name, tag)`. `'auto'` (défaut) dérive le
+     * tag de la version PS majeure + du viewport + de la locale (cf.
+     * VisualTag::resolve()). Un tag libre est utilisé tel quel — il doit
+     * matcher `^[a-z0-9._-]+$`, sinon exception explicite.
      */
-    public function visualCheckpoint(string $name, ?string $selector = null, float $threshold = 0.98, bool $fullPage = true): void
+    public function visualCheckpoint(string $name, ?string $selector = null, float $threshold = 0.98, bool $fullPage = true, string $tag = 'auto'): void
     {
-        $file = $name . '.png';
+        $rawMajorVersion = $this->getMajorVersion();
+        $majorVersion = (is_string($rawMajorVersion) || is_int($rawMajorVersion))
+            && ctype_digit((string) $rawMajorVersion)
+            ? (int) $rawMajorVersion
+            : null;
+
+        [$viewportWidth, $viewportHeight] = $this->getViewportSize();
+
+        $resolvedTag = \PrestaFlow\Library\Visual\VisualTag::resolve(
+            $tag,
+            $majorVersion,
+            $viewportWidth,
+            $viewportHeight,
+            $this->getLocale()
+        );
+
+        $file = $name . '--' . $resolvedTag . '.png';
         $actualPath = \PrestaFlow\Library\Utils\Screenshots::actualPath($file, create: true);
         $refPath = \PrestaFlow\Library\Utils\Screenshots::referencePath($file, create: true);
 
@@ -253,7 +302,7 @@ class CommonPage
         if (!is_file($refPath)) {
             copy($actualPath, $refPath);
             \PrestaFlow\Library\Tests\TestsSuite::recordVisualResult([
-                'name' => $name, 'status' => 'baseline', 'score' => null, 'threshold' => $threshold,
+                'name' => $name, 'tag' => $resolvedTag, 'status' => 'baseline', 'score' => null, 'threshold' => $threshold,
                 'reference' => $refPath, 'actual' => $actualPath, 'diff' => null,
             ]);
             \PrestaFlow\Library\Expects\Expect::that(true)->isTheSameAs(true);
@@ -267,7 +316,7 @@ class CommonPage
 
         $status = $score >= $threshold ? 'pass' : 'fail';
         \PrestaFlow\Library\Tests\TestsSuite::recordVisualResult([
-            'name' => $name, 'status' => $status, 'score' => $score, 'threshold' => $threshold,
+            'name' => $name, 'tag' => $resolvedTag, 'status' => $status, 'score' => $score, 'threshold' => $threshold,
             'reference' => $refPath, 'actual' => $actualPath, 'diff' => $diffPath,
         ]);
 

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -85,6 +85,40 @@ class TestsSuite
     }
 
     /**
+     * Sérialise la tranche de self::$visualResults produite pendant l'exécution
+     * du test courant (de $startIndex jusqu'à la fin) au format attendu dans
+     * results.json (cf. spec MVP2, section « results.json — nouveau bloc »).
+     *
+     * `actual_relpath` / `diff_relpath` ne sont renseignés que pour un statut
+     * `fail` (seul cas où l'action CI a besoin d'uploader ces fichiers) ;
+     * `null` pour `baseline`/`pass`.
+     *
+     * @return array<int, array{name: string, tag: ?string, status: string, score: ?float, threshold: float, actual_relpath: ?string, diff_relpath: ?string}>
+     */
+    private static function buildVisualBlock(int $startIndex): array
+    {
+        $slice = array_slice(self::$visualResults, $startIndex);
+
+        return array_map(static function (array $raw): array {
+            $needsFiles = $raw['status'] === 'fail';
+
+            return [
+                'name' => $raw['name'],
+                'tag' => $raw['tag'] ?? null,
+                'status' => $raw['status'],
+                'score' => $raw['score'],
+                'threshold' => $raw['threshold'],
+                'actual_relpath' => ($needsFiles && !empty($raw['actual']))
+                    ? \PrestaFlow\Library\Utils\Screenshots::relativeVisualPath('actual', basename($raw['actual']))
+                    : null,
+                'diff_relpath' => ($needsFiles && !empty($raw['diff']))
+                    ? \PrestaFlow\Library\Utils\Screenshots::relativeVisualPath('diff', basename($raw['diff']))
+                    : null,
+            ];
+        }, $slice);
+    }
+
+    /**
      * En-têtes HTTP à (ré)appliquer sur CHAQUE page, y compris celles recréées par
      * goToPage (qui ferme puis recrée la page). Alimenté par presetBasicAuth().
      */
@@ -853,6 +887,8 @@ class TestsSuite
             $this->tests = $tests;
 
             foreach ($this->tests as &$test) {
+                $visualStartIndex = count(self::$visualResults);
+
                 try {
                     $startTime = hrtime(true);
 
@@ -900,6 +936,7 @@ class TestsSuite
                     Expect::getNbAssertions();
                     $endTime = hrtime(true);
                     $test['time'] = round(($endTime - $startTime) / 1e+6);
+                    $test['visual'] = self::buildVisualBlock($visualStartIndex);
 
                     match ($test['state']) {
                         'skip' => $this->skipped(test: $test, section: $sectionId, newLine: true),

--- a/src/Visual/VisualTag.php
+++ b/src/Visual/VisualTag.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PrestaFlow\Library\Visual;
+
+/**
+ * Résolution du tag de checkpoint visuel utilisé dans le nommage des fichiers
+ * (`<name>--<tag>.png`) et dans la clé de baseline `(project, name, tag)`
+ * côté API.
+ *
+ * - `$tag !== 'auto'` : utilisé tel quel s'il est filename-safe
+ *   (`^[a-z0-9._-]+$`, insensible à la casse). Sinon, exception explicite —
+ *   les tags libres ne sont jamais réécrits silencieusement.
+ * - `$tag === 'auto'` : dérivé de la version PS majeure, des dimensions du
+ *   viewport et de la locale. Chaque segment manquant est représenté par un
+ *   `?` littéral (jamais omis), pour garder un nombre de segments stable.
+ */
+final class VisualTag
+{
+    private const SAFE_PATTERN = '/^[a-z0-9._-]+$/i';
+
+    public static function resolve(
+        string $tag,
+        ?int $majorVersion,
+        ?int $viewportWidth,
+        ?int $viewportHeight,
+        ?string $locale
+    ): string {
+        if ($tag !== 'auto') {
+            if (preg_match(self::SAFE_PATTERN, $tag) !== 1) {
+                throw new \InvalidArgumentException('visual tag must match [a-z0-9._-]+');
+            }
+
+            return $tag;
+        }
+
+        $major = $majorVersion !== null ? (string) $majorVersion : '?';
+        $width = $viewportWidth !== null ? (string) $viewportWidth : '?';
+        $height = $viewportHeight !== null ? (string) $viewportHeight : '?';
+        $localePart = $locale !== null && $locale !== '' ? $locale : '?';
+
+        return "auto-v{$major}-{$width}x{$height}-{$localePart}";
+    }
+}

--- a/tests/Feature/Visual/ResultsJsonVisualBlockTest.php
+++ b/tests/Feature/Visual/ResultsJsonVisualBlockTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace PrestaFlow\Tests\Feature\Visual;
+
+use PHPUnit\Framework\TestCase;
+use PrestaFlow\Library\Tests\TestsSuite;
+
+/**
+ * Vérifie que le bloc `visual` (spec MVP2, section « results.json — nouveau
+ * bloc ») est bien émis dans le JSON produit par TestsSuite::results(), avec
+ * les clés attendues côté action CI / API (actual_relpath, diff_relpath en
+ * chemins relatifs au projet).
+ */
+final class ResultsJsonVisualBlockTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        TestsSuite::$visualResults = [];
+    }
+
+    protected function tearDown(): void
+    {
+        TestsSuite::$visualResults = [];
+    }
+
+    public function testResultsJsonContainsVisualBlockForFailingCheckpoint(): void
+    {
+        $suite = new class (loadGlobals: false, getBrowser: false) extends TestsSuite {
+        };
+
+        $suite->title = 'Fake visual suite';
+
+        $suite->it('home page visual check', function () {
+            // Simule ce que CommonPage::visualCheckpoint() enregistre pour un
+            // écart détecté (status=fail), sans dépendance à un vrai navigateur.
+            TestsSuite::recordVisualResult([
+                'name' => 'home',
+                'tag' => 'auto-v9-1280x720-fr',
+                'status' => 'fail',
+                'score' => 0.72,
+                'threshold' => 0.98,
+                'reference' => '/tmp/visual-baseline/home--auto-v9-1280x720-fr.png',
+                'actual' => '/tmp/prestaflow/screens/actual/home--auto-v9-1280x720-fr.png',
+                'diff' => '/tmp/prestaflow/screens/diff/home--auto-v9-1280x720-fr.png',
+            ]);
+        });
+
+        $suite->run();
+
+        $results = $suite->results(false);
+        $json = json_encode($results, JSON_PRETTY_PRINT);
+        $decoded = json_decode($json, true);
+
+        $this->assertCount(1, $decoded['tests']);
+        $test = $decoded['tests'][0];
+
+        $this->assertArrayHasKey('visual', $test);
+        $this->assertCount(1, $test['visual']);
+
+        $visual = $test['visual'][0];
+        $this->assertSame('home', $visual['name']);
+        $this->assertSame('auto-v9-1280x720-fr', $visual['tag']);
+        $this->assertSame('fail', $visual['status']);
+        $this->assertSame(0.72, $visual['score']);
+        $this->assertSame(0.98, $visual['threshold']);
+        $this->assertSame('prestaflow/screens/actual/home--auto-v9-1280x720-fr.png', $visual['actual_relpath']);
+        $this->assertSame('prestaflow/screens/diff/home--auto-v9-1280x720-fr.png', $visual['diff_relpath']);
+    }
+
+    public function testBaselineStatusOmitsRelpaths(): void
+    {
+        $suite = new class (loadGlobals: false, getBrowser: false) extends TestsSuite {
+        };
+
+        $suite->title = 'Fake visual suite baseline';
+
+        $suite->it('first run creates baseline', function () {
+            TestsSuite::recordVisualResult([
+                'name' => 'checkout',
+                'tag' => 'auto-v9-1280x720-fr',
+                'status' => 'baseline',
+                'score' => null,
+                'threshold' => 0.98,
+                'reference' => '/tmp/visual-baseline/checkout--auto-v9-1280x720-fr.png',
+                'actual' => '/tmp/prestaflow/screens/actual/checkout--auto-v9-1280x720-fr.png',
+                'diff' => null,
+            ]);
+        });
+
+        $suite->run();
+
+        $results = $suite->results(false);
+        $visual = $results['tests'][0]['visual'][0];
+
+        $this->assertSame('baseline', $visual['status']);
+        $this->assertNull($visual['score']);
+        $this->assertNull($visual['actual_relpath']);
+        $this->assertNull($visual['diff_relpath']);
+    }
+}

--- a/tests/Unit/Visual/VisualCheckpointTagTest.php
+++ b/tests/Unit/Visual/VisualCheckpointTagTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace PrestaFlow\Tests\Unit\Visual;
+
+use PHPUnit\Framework\TestCase;
+use PrestaFlow\Library\Pages\CommonPage;
+use PrestaFlow\Library\Tests\TestsSuite;
+
+final class VisualCheckpointTagTest extends TestCase
+{
+    private string $cwd;
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->cwd = getcwd();
+        $this->tmpDir = sys_get_temp_dir() . '/pfvis_checkpoint_' . getmypid() . '_' . uniqid();
+        @mkdir($this->tmpDir, 0777, true);
+        chdir($this->tmpDir);
+
+        TestsSuite::$visualResults = [];
+    }
+
+    protected function tearDown(): void
+    {
+        chdir($this->cwd);
+        TestsSuite::$visualResults = [];
+    }
+
+    private function png(string $path, int $w = 40, int $h = 40): void
+    {
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0777, true);
+        }
+        $img = imagecreatetruecolor($w, $h);
+        imagefill($img, 0, 0, imagecolorallocate($img, 255, 255, 255));
+        imagepng($img, $path);
+        imagedestroy($img);
+    }
+
+    private function makePage(): CommonPage
+    {
+        $page = new class ('en', '8.1.0', []) extends CommonPage {
+            public function getPage()
+            {
+                return new class {
+                    public function screenshot(array $opts = [])
+                    {
+                        return new class {
+                            public function saveToFile(string $path): void
+                            {
+                                $img = imagecreatetruecolor(40, 40);
+                                imagefill($img, 0, 0, imagecolorallocate($img, 255, 255, 255));
+                                imagepng($img, $path);
+                                imagedestroy($img);
+                            }
+                        };
+                    }
+
+                    public function getFullPageClip()
+                    {
+                        return [];
+                    }
+
+                    public function evaluate(string $js)
+                    {
+                        return new class {
+                            public function getReturnValue()
+                            {
+                                return [1280, 720];
+                            }
+                        };
+                    }
+                };
+            }
+        };
+
+        $page->setMajorVersion('9');
+        $page->setLocale('fr');
+
+        return $page;
+    }
+
+    public function testDefaultAutoTagIsResolvedAndRecorded(): void
+    {
+        $page = $this->makePage();
+
+        $page->visualCheckpoint('home');
+
+        $this->assertCount(1, TestsSuite::$visualResults);
+        $result = TestsSuite::$visualResults[0];
+
+        $this->assertSame('home', $result['name']);
+        $this->assertSame('auto-v9-1280x720-fr', $result['tag']);
+        $this->assertSame('baseline', $result['status']);
+        $this->assertStringContainsString('home--auto-v9-1280x720-fr.png', $result['actual']);
+    }
+
+    public function testExplicitTagIsPreservedVerbatimInResultAndPath(): void
+    {
+        $page = $this->makePage();
+
+        $page->visualCheckpoint('home', tag: 'my-custom');
+
+        $this->assertCount(1, TestsSuite::$visualResults);
+        $result = TestsSuite::$visualResults[0];
+
+        $this->assertSame('my-custom', $result['tag']);
+        $this->assertStringContainsString('home--my-custom.png', $result['actual']);
+        $this->assertStringContainsString('home--my-custom.png', $result['reference']);
+    }
+}

--- a/tests/Unit/Visual/VisualTagTest.php
+++ b/tests/Unit/Visual/VisualTagTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace PrestaFlow\Tests\Unit\Visual;
+
+use PHPUnit\Framework\TestCase;
+use PrestaFlow\Library\Visual\VisualTag;
+
+final class VisualTagTest extends TestCase
+{
+    public function testExplicitTagMatchingSafePatternIsReturnedAsIs(): void
+    {
+        $this->assertSame(
+            'my-custom.tag_1',
+            VisualTag::resolve('my-custom.tag_1', 9, 1280, 720, 'fr')
+        );
+    }
+
+    public function testExplicitTagWithForbiddenCharThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('visual tag must match [a-z0-9._-]+');
+
+        VisualTag::resolve('bad tag', 9, 1280, 720, 'fr');
+    }
+
+    public function testExplicitTagWithColonOrSlashThrows(): void
+    {
+        foreach (['bad:tag', 'bad/tag'] as $tag) {
+            try {
+                VisualTag::resolve($tag, 9, 1280, 720, 'fr');
+                $this->fail("Expected InvalidArgumentException for tag « {$tag} »");
+            } catch (\InvalidArgumentException $e) {
+                $this->assertSame('visual tag must match [a-z0-9._-]+', $e->getMessage());
+            }
+        }
+    }
+
+    public function testAutoTagResolvesFromVersionViewportAndLocale(): void
+    {
+        $this->assertSame(
+            'auto-v9-1280x720-fr',
+            VisualTag::resolve('auto', 9, 1280, 720, 'fr')
+        );
+    }
+
+    public function testAutoTagUsesQuestionMarkPlaceholderForMissingMajorVersion(): void
+    {
+        $this->assertSame(
+            'auto-v?-1280x720-fr',
+            VisualTag::resolve('auto', null, 1280, 720, 'fr')
+        );
+    }
+
+    public function testAutoTagWithAllNullPiecesUsesPlaceholderForEverySegment(): void
+    {
+        $this->assertSame(
+            'auto-v?-?x?-?',
+            VisualTag::resolve('auto', null, null, null, null)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Lot 3 of visual regression MVP2 (spec: [design doc](docs/superpowers/specs/2026-07-28-visual-regression-mvp2-design.md)).

- \`VisualTag::resolve()\` — new class, pure. Handles \`auto\` mode (\`auto-v{major}-{w}x{h}-{locale}\` with \`?\` placeholders for null pieces) and free tags (validated against \`[a-z0-9._-]+\`).
- \`visualCheckpoint()\` — new 5th parameter \`\$tag = 'auto'\`. File naming becomes \`<name>--<resolvedTag>.png\` for actual/reference/diff. Tag stored in \`recordVisualResult()\` payload.
- \`results.json\` per-test payload now carries a \`visual: [...]\` array (\`name\`, \`tag\`, \`status\`, \`score\`, \`threshold\`, \`actual_relpath\`, \`diff_relpath\`). \`*_relpath\` populated only for \`fail\` status.

## Test plan

- [x] \`./vendor/bin/phpunit\` → 90 tests / 413 assertions PASS
- [x] New \`Feature\` test-suite wired in \`phpunit.xml.dist\` (was previously unwired)

## Notes for reviewers

- PS 1.7 major-version strings fall back to \`v?\` in the auto tag (only accepts pure-digit majors like \`8\`/\`9\`). If PS 1.7 visual checkpoints matter in practice, we should extend the parser — flagged out of scope for Lot 3.
- Viewport dimensions read best-effort via \`window.innerWidth/innerHeight\` — no direct getter on the chrome-php Page API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)