### PR TITLE
feat(support): Pdf — lecture PDF pour assertions dans les scénarios

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "inceddy/image-compare": "^1.0",
         "symfony/console": "^6.0",
         "vlucas/phpdotenv": "^5.6",
-        "symfony/event-dispatcher": "^6.0"
+        "symfony/event-dispatcher": "^6.0",
+        "smalot/pdfparser": "^2.11"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0fe3392bbab5c402cf13cb3b41939ed",
+    "content-hash": "817b0afae3a7680c37a36c4657cdc062",
     "packages": [
         {
             "name": "brick/math",
@@ -727,6 +727,57 @@
             "time": "2025-03-06T21:20:56+00:00"
         },
         {
+            "name": "smalot/pdfparser",
+            "version": "v2.12.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/smalot/pdfparser.git",
+                "reference": "2cfa0d92bd557875c9f52a75fde0e8392302a354"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/smalot/pdfparser/zipball/2cfa0d92bd557875c9f52a75fde0e8392302a354",
+                "reference": "2cfa0d92bd557875c9f52a75fde0e8392302a354",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-zlib": "*",
+                "php": ">=7.1",
+                "symfony/polyfill-mbstring": "^1.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Smalot\\PdfParser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastien MALOT",
+                    "email": "sebastien@malot.fr"
+                }
+            ],
+            "description": "Pdf parser library. Can read and extract information from pdf file.",
+            "homepage": "https://www.pdfparser.org",
+            "keywords": [
+                "extract",
+                "parse",
+                "parser",
+                "pdf",
+                "text"
+            ],
+            "support": {
+                "issues": "https://github.com/smalot/pdfparser/issues",
+                "source": "https://github.com/smalot/pdfparser/tree/v2.12.5"
+            },
+            "time": "2026-04-17T11:37:58+00:00"
+        },
+        {
             "name": "symfony/console",
             "version": "v6.4.27",
             "source": {
@@ -1373,16 +1424,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -1434,7 +1485,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -1454,7 +1505,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php80",

--- a/src/Support/Pdf.php
+++ b/src/Support/Pdf.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace PrestaFlow\Library\Support;
+
+use Smalot\PdfParser\Document;
+use Smalot\PdfParser\Parser;
+
+/**
+ * Wrapper mince autour de smalot/pdfparser pour les assertions sur PDF dans
+ * les scénarios (factures, avoirs, bons de livraison, e-tickets…).
+ *
+ * Instanciation :
+ *   Pdf::fromFile('/tmp/facture.pdf')
+ *   Pdf::fromString(file_get_contents(…))
+ *
+ * Lecture :
+ *   ->text()                        // tout le PDF concaténé (\n\n entre pages)
+ *   ->pages()                       // array<string> — 1 entrée par page
+ *   ->contains('TVA', ci: true)     // bool
+ *   ->matches('/TVA\s+([\d,\.]+)/') // array de matches (offset 1)
+ *
+ * Le parser réel n'est instancié qu'à la première lecture (lazy).
+ */
+class Pdf
+{
+    private ?string $binary = null;
+    private ?string $path = null;
+    private ?Document $document = null;
+    private ?string $textCache = null;
+    /** @var string[]|null */
+    private ?array $pagesCache = null;
+
+    private function __construct() {}
+
+    public static function fromFile(string $path): self
+    {
+        if (!is_file($path) || !is_readable($path)) {
+            throw new \RuntimeException("Pdf::fromFile : fichier introuvable ou illisible « {$path} »");
+        }
+        $pdf = new self();
+        $pdf->path = $path;
+        return $pdf;
+    }
+
+    public static function fromString(string $binary): self
+    {
+        if ($binary === '') {
+            throw new \RuntimeException('Pdf::fromString : contenu vide');
+        }
+        $pdf = new self();
+        $pdf->binary = $binary;
+        return $pdf;
+    }
+
+    /** Texte concaténé de toutes les pages (séparateur `\n\n`). */
+    public function text(): string
+    {
+        if ($this->textCache !== null) {
+            return $this->textCache;
+        }
+        return $this->textCache = implode("\n\n", $this->pages());
+    }
+
+    /**
+     * Texte de chaque page dans l'ordre. Utile quand on veut asserter qu'une
+     * mention est bien sur la 1re page (ex. mention légale d'exemption TVA).
+     *
+     * @return string[]
+     */
+    public function pages(): array
+    {
+        if ($this->pagesCache !== null) {
+            return $this->pagesCache;
+        }
+        $out = [];
+        foreach ($this->document()->getPages() as $page) {
+            $out[] = (string) $page->getText();
+        }
+        return $this->pagesCache = $out;
+    }
+
+    /**
+     * true si $needle est dans le texte. Casse-insensible par défaut :
+     * l'extraction PDF conserve la casse d'origine (souvent MAJUSCULES pour
+     * les mentions légales) et on veut asserter du texte lisible côté humain.
+     */
+    public function contains(string $needle, bool $caseSensitive = false): bool
+    {
+        if ($needle === '') {
+            return true;
+        }
+        $haystack = $this->text();
+        return $caseSensitive
+            ? str_contains($haystack, $needle)
+            : stripos($haystack, $needle) !== false;
+    }
+
+    /**
+     * Retourne les matches de $regex sur le texte concaténé. Renvoie un
+     * tableau vide si aucun match. Multi-lignes et Unicode activés par
+     * défaut ; passez votre propre delimiter+flags si vous voulez plus fin.
+     *
+     * @return string[]|array<int,array<int,string>>
+     */
+    public function matches(string $regex, int $group = 0): array
+    {
+        if (@preg_match($regex, '') === false) {
+            throw new \RuntimeException("Pdf::matches : regex invalide « {$regex} »");
+        }
+        if (!preg_match_all($regex, $this->text(), $m)) {
+            return [];
+        }
+        return $m[$group] ?? [];
+    }
+
+    /** Nombre de pages. */
+    public function pageCount(): int
+    {
+        return count($this->pages());
+    }
+
+    private function document(): Document
+    {
+        if ($this->document !== null) {
+            return $this->document;
+        }
+        $parser = new Parser();
+        $this->document = $this->path !== null
+            ? $parser->parseFile($this->path)
+            : $parser->parseContent((string) $this->binary);
+        return $this->document;
+    }
+}

--- a/tests/Unit/Support/PdfTest.php
+++ b/tests/Unit/Support/PdfTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace PrestaFlow\Tests\Unit\Support;
+
+use PHPUnit\Framework\TestCase;
+use PrestaFlow\Library\Support\Pdf;
+
+final class PdfTest extends TestCase
+{
+    private string $fixture;
+
+    protected function setUp(): void
+    {
+        $this->fixture = __DIR__ . '/fixtures/facture.pdf';
+    }
+
+    public function testFromFileReadsText(): void
+    {
+        $pdf = Pdf::fromFile($this->fixture);
+        $text = $pdf->text();
+        $this->assertStringContainsString('Facture', $text);
+        $this->assertStringContainsString('TVA', $text);
+    }
+
+    public function testFromStringReadsSameText(): void
+    {
+        $pdf = Pdf::fromString((string) file_get_contents($this->fixture));
+        $this->assertStringContainsString('123', $pdf->text());
+    }
+
+    public function testFromFileThrowsOnMissingFile(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/introuvable/');
+        Pdf::fromFile('/does/not/exist.pdf');
+    }
+
+    public function testFromStringThrowsOnEmpty(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        Pdf::fromString('');
+    }
+
+    public function testPagesReturnsAtLeastOne(): void
+    {
+        $pdf = Pdf::fromFile($this->fixture);
+        $pages = $pdf->pages();
+        $this->assertGreaterThanOrEqual(1, count($pages));
+        $this->assertSame(count($pages), $pdf->pageCount());
+    }
+
+    public function testContainsIsCaseInsensitiveByDefault(): void
+    {
+        $pdf = Pdf::fromFile($this->fixture);
+        $this->assertTrue($pdf->contains('facture'));   // fixture a "Facture"
+        $this->assertTrue($pdf->contains('FACTURE'));
+        $this->assertFalse($pdf->contains('facture', caseSensitive: true));
+    }
+
+    public function testContainsEmptyNeedleIsTrue(): void
+    {
+        $this->assertTrue(Pdf::fromFile($this->fixture)->contains(''));
+    }
+
+    public function testMatchesReturnsCapturedGroup(): void
+    {
+        $pdf = Pdf::fromFile($this->fixture);
+        // « Facture #123 » ou « Facture 123 » selon le rendu
+        $ids = $pdf->matches('/Facture\s*#?\s*(\d+)/', 1);
+        $this->assertNotEmpty($ids);
+        $this->assertSame('123', $ids[0]);
+    }
+
+    public function testMatchesReturnsEmptyOnNoMatch(): void
+    {
+        $pdf = Pdf::fromFile($this->fixture);
+        $this->assertSame([], $pdf->matches('/absolument-absent-du-doc/'));
+    }
+
+    public function testMatchesThrowsOnInvalidRegex(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        Pdf::fromFile($this->fixture)->matches('not-a-regex');
+    }
+}

--- a/tests/Unit/Support/fixtures/facture.pdf
+++ b/tests/Unit/Support/fixtures/facture.pdf
@@ -1,0 +1,38 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /MediaBox [0 0 612 792] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 94 >>
+stream
+BT
+/F1 12 Tf
+100 700 Td
+(Facture #123 - TVA 21%) Tj
+100 680 Td
+(Ligne totale HT: 123.45) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+0000000241 00000 n
+0000000385 00000 n
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+455
+%%EOF


### PR DESCRIPTION
## Résumé

Ajoute `PrestaFlow\Library\Support\Pdf`, wrapper mince autour de [`smalot/pdfparser`](https://github.com/smalot/pdfparser) pour asserter sur du texte extrait d'un PDF.

## Motivation

Cas d'usage récurrents dans les scénarios PrestaShop : vérifier qu'une facture porte bien la mention légale d'exemption TVA, qu'un avoir affiche le bon montant plafonné, qu'un bon de livraison contient la bonne adresse, qu'un e-ticket / carte cadeau imprime les bons éléments. Aujourd'hui chaque projet doit rebrancher son propre parser.

## API

```php
use PrestaFlow\Library\Support\Pdf;

$pdf = Pdf::fromFile('/tmp/facture.pdf');   // ou Pdf::fromString($binary)

$pdf->text();                                // tout le PDF concaténé
$pdf->pages();                               // string[] — une entrée par page
$pdf->pageCount();
$pdf->contains('TVA');                       // case-insensible par défaut
$pdf->contains('TVA', caseSensitive: true);
$pdf->matches('/Facture\s*#?\s*(\d+)/', 1);  // captures
```

## Choix de design

- **Parser lazy** : instancié à la première lecture, pas à la construction. `Pdf::fromFile()` ne fait qu'un `is_readable()`.
- **Case-insensible par défaut** pour `contains` : l'extraction PDF conserve la casse d'origine (souvent MAJUSCULES pour les mentions légales), on veut asserter du texte lisible côté humain sans y penser.
- **`matches` throw sur regex invalide** au lieu de renvoyer `false` silencieusement — évite le classique « pourquoi mon assert passe ? ».
- **Aucune méthode d'écriture** : la lib ne génère pas de PDF, elle en lit. Génération = responsabilité du projet (dompdf, mpdf, tcpdf…).

## Dépendance

`smalot/pdfparser: ^2.11` en require (pas require-dev) — c'est une feature runtime des scénarios.

## Tests

10 tests PHPUnit, fixture PDF autonome (632 octets, hand-crafted dans `tests/Unit/Support/fixtures/`) — aucune dépendance externe pour la CI. Couvre : fromFile / fromString, text / pages, contains (case), matches (captures + regex invalide + no-match), erreurs (fichier absent, contenu vide).

    OK (10 tests, 17 assertions)