### PR TITLE
feat(TestsSuite): PRESTAFLOW_EXTRA_HEADERS — en-têtes HTTP arbitraires depuis l'env

### DIFF
--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -515,6 +515,12 @@ class TestsSuite
         // n'applique pas aux requêtes XHR ni toujours aux redirections.
         $this->presetBasicAuth();
 
+        // 2b) En-têtes HTTP arbitraires depuis l'environnement (PRESTAFLOW_EXTRA_HEADERS,
+        // JSON objet). Utiles pour un bypass WAF/CDN (Cloudflare WAF Skip rule via
+        // `X-CI-Bypass: <secret>`), du request tracing (`X-Request-Id`), etc.
+        // Posés APRÈS Basic Auth pour pouvoir les surcharger si besoin.
+        $this->presetExtraHeadersFromEnv();
+
         // 3) Pré-réglage de cookies fournis via l'environnement (PRESTAFLOW_COOKIES,
         // JSON), avant toute navigation. Pratique pour neutraliser un bandeau de
         // consentement (RGPD) sur un environnement protégé/preprod.
@@ -559,6 +565,66 @@ class TestsSuite
         }
 
         // Applique sur la page courante (première navigation).
+        TestsSuite::applyExtraHttpHeaders();
+    }
+
+    /**
+     * En-têtes HTTP arbitraires depuis l'environnement PRESTAFLOW_EXTRA_HEADERS.
+     *
+     * Format : objet JSON `{"Header-Name": "value", ...}`. Chaque paire est
+     * fusionnée dans self::$extraHttpHeaders — donc appliquée à toutes les
+     * requêtes (navigation top-level, sous-ressources, XHR) et réappliquée
+     * après chaque recreatePage(). Mêmes garanties que presetBasicAuth().
+     *
+     * Cas d'usage :
+     *  - Bypass WAF/CDN (ex. Cloudflare WAF Skip rule : `X-CI-Bypass: <secret>`)
+     *  - Request tracing (`X-Request-Id`, `X-CI-Run: <id>`)
+     *  - En-têtes spécifiques d'un edge (Netlify, Vercel, etc.)
+     *
+     * Best-effort : JSON invalide → warning stderr, on n'interrompt pas le
+     * bootstrap. Les clés non-string ou valeurs non-string sont ignorées.
+     */
+    protected function presetExtraHeadersFromEnv(): void
+    {
+        $raw = $_ENV['PRESTAFLOW_EXTRA_HEADERS'] ?? null;
+        if ($raw === null || $raw === '') {
+            return;
+        }
+
+        $decoded = json_decode((string) $raw, true);
+        if (!is_array($decoded)) {
+            fwrite(STDERR, "[PrestaFlow] PRESTAFLOW_EXTRA_HEADERS: JSON invalide, ignoré.\n");
+            return;
+        }
+
+        $added = [];
+        foreach ($decoded as $name => $value) {
+            if (!is_string($name) || $name === '' || !is_scalar($value)) {
+                continue;
+            }
+            $added[$name] = (string) $value;
+        }
+        if ($added === []) {
+            return;
+        }
+
+        // Merge : on préserve les en-têtes déjà posés (ex. Authorization par
+        // presetBasicAuth). L'ordre d'appel dans before() fait que Basic Auth
+        // gagne — sauf si l'utilisateur redéfinit explicitement 'Authorization'
+        // dans PRESTAFLOW_EXTRA_HEADERS (surcharge volontaire).
+        TestsSuite::$extraHttpHeaders = array_merge(TestsSuite::$extraHttpHeaders, $added);
+
+        // Même chemin d'application que Basic Auth : au niveau de la connexion
+        // pour héritage par chaque nouvelle page, puis sur la page courante.
+        $browser = TestsSuite::getBrowser();
+        if ($browser) {
+            try {
+                $browser->getConnection()->setConnectionHttpHeaders(TestsSuite::$extraHttpHeaders);
+            } catch (Throwable $e) {
+                // best-effort
+            }
+        }
+
         TestsSuite::applyExtraHttpHeaders();
     }
 

--- a/tests/Unit/Tests/ExtraHeadersFromEnvTest.php
+++ b/tests/Unit/Tests/ExtraHeadersFromEnvTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace PrestaFlow\Tests\Unit\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PrestaFlow\Library\Tests\TestsSuite;
+
+/**
+ * Tests unitaires pour presetExtraHeadersFromEnv() — chemin env → $extraHttpHeaders.
+ *
+ * On invoque directement la méthode protégée via réflexion pour éviter d'avoir
+ * à booter un browser (côté I/O du preset — setConnectionHttpHeaders /
+ * applyExtraHttpHeaders — sont no-op sans browser).
+ */
+final class ExtraHeadersFromEnvTest extends TestCase
+{
+    private array $envBackup;
+    private array $headersBackup;
+
+    protected function setUp(): void
+    {
+        $this->envBackup = [
+            'PRESTAFLOW_EXTRA_HEADERS' => $_ENV['PRESTAFLOW_EXTRA_HEADERS'] ?? null,
+        ];
+        $this->headersBackup = TestsSuite::$extraHttpHeaders;
+        TestsSuite::$extraHttpHeaders = [];
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envBackup as $k => $v) {
+            if ($v === null) {
+                unset($_ENV[$k]);
+            } else {
+                $_ENV[$k] = $v;
+            }
+        }
+        TestsSuite::$extraHttpHeaders = $this->headersBackup;
+    }
+
+    private function invoke(): void
+    {
+        $suite = new class extends TestsSuite {
+            public function callPreset(): void
+            {
+                $this->presetExtraHeadersFromEnv();
+            }
+        };
+        $suite->callPreset();
+    }
+
+    public function testEmptyEnvIsNoOp(): void
+    {
+        unset($_ENV['PRESTAFLOW_EXTRA_HEADERS']);
+        $this->invoke();
+        $this->assertSame([], TestsSuite::$extraHttpHeaders);
+    }
+
+    public function testEmptyStringIsNoOp(): void
+    {
+        $_ENV['PRESTAFLOW_EXTRA_HEADERS'] = '';
+        $this->invoke();
+        $this->assertSame([], TestsSuite::$extraHttpHeaders);
+    }
+
+    public function testValidJsonPopulatesHeaders(): void
+    {
+        $_ENV['PRESTAFLOW_EXTRA_HEADERS'] = '{"X-CI-Bypass":"secret","X-Request-Id":"abc"}';
+        $this->invoke();
+        $this->assertSame([
+            'X-CI-Bypass' => 'secret',
+            'X-Request-Id' => 'abc',
+        ], TestsSuite::$extraHttpHeaders);
+    }
+
+    public function testScalarValuesAreStringifiedNonScalarsSkipped(): void
+    {
+        $_ENV['PRESTAFLOW_EXTRA_HEADERS'] = '{"X-Int":42,"X-Bool":true,"X-Null":null,"X-Arr":["nope"]}';
+        $this->invoke();
+        $this->assertSame([
+            'X-Int' => '42',
+            'X-Bool' => '1',    // (string) true → "1"
+        ], TestsSuite::$extraHttpHeaders);
+    }
+
+    public function testInvalidJsonIsNoOpWithStderrWarning(): void
+    {
+        $_ENV['PRESTAFLOW_EXTRA_HEADERS'] = '{not-json';
+        // Capture stderr pour vérifier le warning
+        $tmp = tmpfile();
+        $meta = stream_get_meta_data($tmp);
+        $origStderr = defined('STDERR') ? STDERR : null;
+
+        // On ne peut pas facilement rediriger STDERR sans hack ; on se contente
+        // de vérifier l'effet fonctionnel (no-op) — le warning est best-effort.
+        $this->invoke();
+        $this->assertSame([], TestsSuite::$extraHttpHeaders);
+    }
+
+    public function testNonObjectJsonArrayIsRejected(): void
+    {
+        $_ENV['PRESTAFLOW_EXTRA_HEADERS'] = '["not","an","object"]';
+        // json_decode( , true) le rend en array indexé → clés non-string → skipped
+        $this->invoke();
+        $this->assertSame([], TestsSuite::$extraHttpHeaders);
+    }
+
+    public function testMergePreservesExistingHeadersUnlessOverridden(): void
+    {
+        TestsSuite::$extraHttpHeaders = ['Authorization' => 'Basic existing', 'X-Keep' => '1'];
+        $_ENV['PRESTAFLOW_EXTRA_HEADERS'] = '{"X-CI-Bypass":"secret","Authorization":"Bearer override"}';
+        $this->invoke();
+        // Le merge donne priorité aux valeurs env (surcharge volontaire possible).
+        $this->assertSame([
+            'Authorization' => 'Bearer override',
+            'X-Keep' => '1',
+            'X-CI-Bypass' => 'secret',
+        ], TestsSuite::$extraHttpHeaders);
+    }
+
+    public function testEmptyKeyIsRejected(): void
+    {
+        $_ENV['PRESTAFLOW_EXTRA_HEADERS'] = '{"":"empty-key","X-Ok":"v"}';
+        $this->invoke();
+        $this->assertSame(['X-Ok' => 'v'], TestsSuite::$extraHttpHeaders);
+    }
+}


### PR DESCRIPTION
## Résumé

Nouvel env `PRESTAFLOW_EXTRA_HEADERS` (JSON objet) qui alimente `TestsSuite::$extraHttpHeaders` — donc appliqué à toutes les requêtes du navigateur, réappliqué après chaque `recreatePage()`, hérité par les pages recréées via `goToPage()`.

```
PRESTAFLOW_EXTRA_HEADERS='{"X-CI-Bypass":"secret","X-Request-Id":"abc"}'
```

## Motivation

Un vrai cas rencontré chez lacitedesnuages.be : preprod derrière Cloudflare avec Bot Fight Mode + détection headless. La 2ᵉ navigation d'un scénario tombe dans le challenge Turnstile → capture inutilisable, assertions foireuses.

Le contournement propre est une **WAF Custom Rule Cloudflare** :

```
if (http.request.headers["x-ci-bypass"] eq "<secret_partagé>") skip
```

Il fallait un mécanisme lib pour poser cet en-tête sur toutes les requêtes, sans hardcoder le nom du header (les WAF, CDN et edges custom ont chacun leur convention).

## Design

Même chemin que [`presetBasicAuth()`](../blob/main/src/Tests/TestsSuite.php) — solide, éprouvé :

1. Parse JSON, merge dans `self::$extraHttpHeaders`.
2. `setConnectionHttpHeaders()` au niveau du navigateur → hérité par chaque `createPage()`.
3. `applyExtraHttpHeaders()` sur la page courante pour la toute 1re nav.

Ordre d'appel dans `before()` : Basic Auth puis Extra Headers → les valeurs env peuvent surcharger un en-tête déjà posé (surcharge volontaire pour `Authorization` p.ex.).

## Robustesse

- **Env absent / chaîne vide** → no-op silencieux (aucun warning bruyant).
- **JSON invalide** → warning stderr, on continue. Ne casse pas le bootstrap.
- **Clés non-string / valeurs non-scalaires** → ignorées (`array` / `null` / `object`).
- **Booléens/entiers** → castés en string (`true` → `"1"`, `42` → `"42"`).

## Cas d'usage au-delà du bypass Cloudflare

- Request tracing : `X-Request-Id: <ci-run-id>`
- Edge functions custom (Netlify, Vercel)
- Feature flags côté serveur (`X-Feature-Flag: preview-mode-2`)
- WAF / CDN autres que Cloudflare (Fastly, Sucuri, StackPath)

## Tests

8 tests unitaires (fichier neuf), tous verts. Couvre : env absent, chaîne vide, JSON valide, JSON invalide, JSON array indexé, scalaires vs non-scalaires, clé vide, merge avec surcharge.

    OK (8 tests, 8 assertions)

## Upgrade

Aucun changement rétrocompatible. `composer update prestaflow/php-library:^1.7` (ou `dev-main`).