### PR TITLE
Ajout de helpers  pour les attentes et rechargements

### DIFF
--- a/src/Pages/Common/BackOffice/Login/Page.php
+++ b/src/Pages/Common/BackOffice/Login/Page.php
@@ -50,8 +50,7 @@ class Page extends BasePage
 
         // Wait for navigation if login is successful
         if ($waitForNavigation) {
-            $this->click($this->getSelector('submitLoginButton'));
-            $this->waitForPageReload();
+            $this->clickAndWaitReload($this->getSelector('submitLoginButton'));
         } else {
             $this->click($this->getSelector('submitLoginButton'));
         }

--- a/src/Pages/Common/BackOffice/OrderView/Page.php
+++ b/src/Pages/Common/BackOffice/OrderView/Page.php
@@ -45,8 +45,7 @@ class Page extends BasePage
         // The status field is a select2: set the underlying <select> value by
         // option label and fire "change" (the lib's selectValue does this).
         $this->selectValue($this->getSelector('statusSelect'), $status);
-        $this->click($this->getSelector('updateStatusButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('updateStatusButton'));
     }
 
     public function hasStatusInHistory(string $status): bool
@@ -91,8 +90,7 @@ class Page extends BasePage
             $sel,
             $val
         ));
-        $this->click($this->getSelector('trackingSaveButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('trackingSaveButton'));
     }
 
     public function getTracking(): string

--- a/src/Pages/Common/BackOffice/Orders/Page.php
+++ b/src/Pages/Common/BackOffice/Orders/Page.php
@@ -33,8 +33,7 @@ class Page extends BasePage
     public function filterByReference(string $reference): void
     {
         $this->setValue($this->getSelector('filterReferenceInput'), $reference);
-        $this->click($this->getSelector('searchButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('searchButton'));
     }
 
     public function getOrderReferenceInList(int $row = 1): string
@@ -44,7 +43,6 @@ class Page extends BasePage
 
     public function openOrder(int $row = 1): void
     {
-        $this->click($this->getSelector('listRowLink', ['row' => $row]));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('listRowLink', ['row' => $row]));
     }
 }

--- a/src/Pages/Common/BackOffice/Products/Page.php
+++ b/src/Pages/Common/BackOffice/Products/Page.php
@@ -53,14 +53,12 @@ class Page extends BasePage
     public function filterByName(string $name): void
     {
         $this->setValue($this->getSelector('filterNameInput'), $name);
-        $this->click($this->getSelector('searchButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('searchButton'));
     }
 
     public function resetFilter(): void
     {
-        $this->click($this->getSelector('resetButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('resetButton'));
     }
 
     public function getListCount(): int
@@ -96,8 +94,7 @@ class Page extends BasePage
         // "Standard product" is pre-selected. Clicking "Add new product" submits
         // the create form and redirects to /products/{id}/edit, rendering the
         // full editable product form.
-        $this->click($this->getSelector('createProductButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('createProductButton'));
     }
 
     public function createProduct(string $name, float $price = 0, int $quantity = 0): void
@@ -111,8 +108,7 @@ class Page extends BasePage
         $this->setValueByJs($this->getSelector('formQuantityInput'), (string) $quantity);
         // Enable the product BEFORE saving so the online state persists.
         $this->enableProduct();
-        $this->click($this->getSelector('formSaveButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('formSaveButton'));
     }
 
     public function deleteProduct(int $row = 1): void
@@ -125,8 +121,7 @@ class Page extends BasePage
             $this->getPage()->waitUntilContainsElement($this->getSelector('deleteConfirmButton'), 10000);
         } catch (\Throwable $e) {
         }
-        $this->click($this->getSelector('deleteConfirmButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('deleteConfirmButton'));
     }
 
     public function getSuccessMessage(): string
@@ -165,16 +160,14 @@ class Page extends BasePage
 
     public function openProduct(int $row = 1): void
     {
-        $this->click($this->getSelector('listRowLink', ['row' => $row]));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('listRowLink', ['row' => $row]));
     }
 
     public function updatePrice(float $price): void
     {
         // The price field is on the (inactive) Pricing tab; set it via JS.
         $this->setValueByJs($this->getSelector('formPriceInput'), (string) $price);
-        $this->click($this->getSelector('formSaveButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('formSaveButton'));
     }
 
     public function getFormPrice(): string

--- a/src/Pages/Common/FrontOffice/Cart/Page.php
+++ b/src/Pages/Common/FrontOffice/Cart/Page.php
@@ -26,7 +26,6 @@ class Page extends BasePage
 
     public function proceedToCheckout(): void
     {
-        $this->click($this->getSelector('checkoutButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('checkoutButton'));
     }
 }

--- a/src/Pages/Common/FrontOffice/Checkout/Page.php
+++ b/src/Pages/Common/FrontOffice/Checkout/Page.php
@@ -36,8 +36,7 @@ class Page extends BasePage
 
     public function confirmAddresses(): void
     {
-        $this->click($this->getSelector('addressesContinueButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('addressesContinueButton'));
     }
 
     public function checkoutAsGuest(string $email, string $firstName, string $lastName): void
@@ -55,8 +54,7 @@ class Page extends BasePage
             '(function(){[].slice.call(document.querySelectorAll("#checkout-personal-information-step input[type=checkbox]")).forEach(function(c){if(c.required&&!c.checked){c.click();}});})()'
         );
 
-        $this->click($this->getSelector('personalContinueButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('personalContinueButton'));
     }
 
     public function fillNewAddress(array $address): void
@@ -69,22 +67,19 @@ class Page extends BasePage
         }
         $this->setValue($this->getSelector('addressPhoneInput'), $address['phone'] ?? '');
 
-        $this->click($this->getSelector('addressesContinueButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('addressesContinueButton'));
     }
 
     public function chooseShipping(): void
     {
         $this->click($this->getSelector('shippingOption'));
-        $this->click($this->getSelector('shippingContinueButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('shippingContinueButton'));
     }
 
     public function choosePaymentAndConfirm(): void
     {
         $this->click($this->getSelector('paymentOption'));
         $this->click($this->getSelector('termsCheckbox'));
-        $this->click($this->getSelector('placeOrderButton'));
-        $this->waitForPageReload();
+        $this->clickAndWaitReload($this->getSelector('placeOrderButton'));
     }
 }

--- a/src/Pages/Common/FrontOffice/Login/Page.php
+++ b/src/Pages/Common/FrontOffice/Login/Page.php
@@ -38,9 +38,7 @@ class Page extends BasePage
 
         // Wait for navigation if login is successful
         if ($waitForNavigation) {
-            $this->click($this->getSelector('submitLoginButton'));
-            $this->waitForPageReload();
-            //TestsSuite::getPage()->waitForReload();
+            $this->clickAndWaitReload($this->getSelector('submitLoginButton'));
         } else {
             $this->click($this->getSelector('submitLoginButton'));
         }

--- a/src/Pages/CommonPage.php
+++ b/src/Pages/CommonPage.php
@@ -523,6 +523,39 @@ class CommonPage
         return true;
     }
 
+    public function waitUntil(callable $condition, int $timeout = 10000, string $message = 'Condition was not met.'): void
+    {
+        $deadline = microtime(true) + ($timeout / 1000);
+
+        do {
+            if ($condition()) {
+                return;
+            }
+
+            usleep(100000);
+        } while (microtime(true) < $deadline);
+
+        throw new \RuntimeException($message);
+    }
+
+    public function waitVisible($selector, int $timeout = 10000, ?string $message = null): void
+    {
+        $this->waitUntil(
+            fn () => $this->isVisible($selector, 100),
+            $timeout,
+            $message ?? sprintf('Element did not become visible: %s', $selector)
+        );
+    }
+
+    public function waitHidden($selector, int $timeout = 10000, ?string $message = null): void
+    {
+        $this->waitUntil(
+            fn () => !$this->isVisible($selector, 100),
+            $timeout,
+            $message ?? sprintf('Element did not become hidden: %s', $selector)
+        );
+    }
+
     public function isVisible($selector, $timeout = 1000)
     {
         return $this->elementIsVisible($selector, $timeout);

--- a/src/Pages/CommonPage.php
+++ b/src/Pages/CommonPage.php
@@ -556,6 +556,19 @@ class CommonPage
         );
     }
 
+    public function waitForText(string $text, int $timeout = 10000, string $selector = 'body', ?string $message = null): void
+    {
+        $this->waitUntil(
+            function () use ($selector, $text) {
+                $content = $this->getTextContent($selector, 1, true, 100);
+
+                return is_string($content) && str_contains($content, $text);
+            },
+            $timeout,
+            $message ?? sprintf('Text did not appear in %s: %s', $selector, $text)
+        );
+    }
+
     public function isVisible($selector, $timeout = 1000)
     {
         return $this->elementIsVisible($selector, $timeout);

--- a/src/Pages/CommonPage.php
+++ b/src/Pages/CommonPage.php
@@ -434,6 +434,12 @@ class CommonPage
         return $this->getPage()->mouse()->find($selector, $nth)->click();
     }
 
+    public function clickAndWaitReload($selector, $nth = 1): void
+    {
+        $this->click($selector, $nth);
+        $this->waitForPageReload();
+    }
+
     public function waitForPageReload()
     {
         try {

--- a/src/Tests/TestsSuite.php
+++ b/src/Tests/TestsSuite.php
@@ -616,16 +616,16 @@ class TestsSuite
 
         // Même chemin d'application que Basic Auth : au niveau de la connexion
         // pour héritage par chaque nouvelle page, puis sur la page courante.
-        $browser = TestsSuite::getBrowser();
+        $browser = TestsSuite::getBrowser(force: false);
         if ($browser) {
             try {
                 $browser->getConnection()->setConnectionHttpHeaders(TestsSuite::$extraHttpHeaders);
             } catch (Throwable $e) {
                 // best-effort
             }
-        }
 
-        TestsSuite::applyExtraHttpHeaders();
+            TestsSuite::applyExtraHttpHeaders();
+        }
     }
 
     /**

--- a/tests/Unit/Pages/CommonPageActionTest.php
+++ b/tests/Unit/Pages/CommonPageActionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PrestaFlow\Tests\Unit\Pages;
+
+use PHPUnit\Framework\TestCase;
+use PrestaFlow\Library\Pages\CommonPage;
+
+final class CommonPageActionTest extends TestCase
+{
+    public function testClickAndWaitReloadRunsBothActionsInOrder(): void
+    {
+        $page = new class ('en', '8.1.0', []) extends CommonPage {
+            public array $calls = [];
+
+            public function click($selector, $nth = 1)
+            {
+                $this->calls[] = ['click', $selector, $nth];
+            }
+
+            public function waitForPageReload()
+            {
+                $this->calls[] = ['reload'];
+            }
+        };
+
+        $page->clickAndWaitReload('#save', 2);
+
+        $this->assertSame([['click', '#save', 2], ['reload']], $page->calls);
+    }
+}

--- a/tests/Unit/Pages/CommonPageWaitTest.php
+++ b/tests/Unit/Pages/CommonPageWaitTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace PrestaFlow\Tests\Unit\Pages;
+
+use PHPUnit\Framework\TestCase;
+use PrestaFlow\Library\Pages\CommonPage;
+
+final class CommonPageWaitTest extends TestCase
+{
+    public function testWaitUntilStopsWhenConditionIsMet(): void
+    {
+        $page = $this->makePage();
+        $attempts = 0;
+
+        $page->waitUntil(function () use (&$attempts) {
+            ++$attempts;
+
+            return $attempts === 2;
+        }, 500);
+
+        $this->assertSame(2, $attempts);
+    }
+
+    public function testWaitUntilUsesProvidedFailureMessage(): void
+    {
+        $page = $this->makePage();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Expected condition did not happen.');
+
+        $page->waitUntil(fn () => false, 1, 'Expected condition did not happen.');
+    }
+
+    public function testWaitVisibleWaitsForVisibleElement(): void
+    {
+        $page = $this->makePage([false, true]);
+
+        $page->waitVisible('#save', 500);
+
+        $this->assertSame(2, $page->visibilityChecks);
+    }
+
+    public function testWaitHiddenWaitsForElementToDisappear(): void
+    {
+        $page = $this->makePage([true, false]);
+
+        $page->waitHidden('.loading', 500);
+
+        $this->assertSame(2, $page->visibilityChecks);
+    }
+
+    public function testWaitVisibleBuildsUsefulDefaultMessage(): void
+    {
+        $page = $this->makePage([false]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Element did not become visible: #missing');
+
+        $page->waitVisible('#missing', 1);
+    }
+
+    private function makePage(array $visibility = []): CommonPage
+    {
+        return new class ('en', '8.1.0', [], [], $visibility) extends CommonPage {
+            public int $visibilityChecks = 0;
+
+            private array $visibility;
+
+            public function __construct(string $locale, string $patchVersion, array $globals, array $customs, array $visibility)
+            {
+                parent::__construct($locale, $patchVersion, $globals, $customs);
+                $this->visibility = $visibility;
+            }
+
+            public function isVisible($selector, $timeout = 1000)
+            {
+                ++$this->visibilityChecks;
+
+                if ($this->visibility === []) {
+                    return false;
+                }
+
+                if (count($this->visibility) === 1) {
+                    return $this->visibility[0];
+                }
+
+                return array_shift($this->visibility);
+            }
+        };
+    }
+}

--- a/tests/Unit/Pages/CommonPageWaitTest.php
+++ b/tests/Unit/Pages/CommonPageWaitTest.php
@@ -59,6 +59,35 @@ final class CommonPageWaitTest extends TestCase
         $page->waitVisible('#missing', 1);
     }
 
+    public function testWaitForTextWaitsUntilTextAppears(): void
+    {
+        $page = $this->makeTextPage(['Loading', 'Order confirmed']);
+
+        $page->waitForText('Order confirmed', 500);
+
+        $this->assertSame(2, $page->textChecks);
+        $this->assertSame('body', $page->lastSelector);
+    }
+
+    public function testWaitForTextSupportsScopedSelector(): void
+    {
+        $page = $this->makeTextPage(['Saved']);
+
+        $page->waitForText('Saved', 500, '.notification');
+
+        $this->assertSame('.notification', $page->lastSelector);
+    }
+
+    public function testWaitForTextUsesProvidedFailureMessage(): void
+    {
+        $page = $this->makeTextPage(['Still loading']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Confirmation message did not appear.');
+
+        $page->waitForText('Done', 1, 'body', 'Confirmation message did not appear.');
+    }
+
     private function makePage(array $visibility = []): CommonPage
     {
         return new class ('en', '8.1.0', [], [], $visibility) extends CommonPage {
@@ -85,6 +114,39 @@ final class CommonPageWaitTest extends TestCase
                 }
 
                 return array_shift($this->visibility);
+            }
+        };
+    }
+
+    private function makeTextPage(array $contents): CommonPage
+    {
+        return new class ('en', '8.1.0', [], [], $contents) extends CommonPage {
+            public int $textChecks = 0;
+
+            public string $lastSelector = '';
+
+            private array $contents;
+
+            public function __construct(string $locale, string $patchVersion, array $globals, array $customs, array $contents)
+            {
+                parent::__construct($locale, $patchVersion, $globals, $customs);
+                $this->contents = $contents;
+            }
+
+            public function getTextContent($selector, $index = 1, $waitForSelector = true, $timeout = 3000)
+            {
+                ++$this->textChecks;
+                $this->lastSelector = $selector;
+
+                if ($this->contents === []) {
+                    return false;
+                }
+
+                if (count($this->contents) === 1) {
+                    return $this->contents[0];
+                }
+
+                return array_shift($this->contents);
             }
         };
     }

--- a/tests/Unit/Pages/CommonPageWaitTest.php
+++ b/tests/Unit/Pages/CommonPageWaitTest.php
@@ -33,25 +33,30 @@ final class CommonPageWaitTest extends TestCase
 
     public function testWaitVisibleWaitsForVisibleElement(): void
     {
-        $page = $this->makePage([false, true]);
+        $page = $this->mockPage('isVisible');
+        $page->expects($this->exactly(2))
+            ->method('isVisible')
+            ->with('#save', 100)
+            ->willReturnOnConsecutiveCalls(false, true);
 
         $page->waitVisible('#save', 500);
-
-        $this->assertSame(2, $page->visibilityChecks);
     }
 
     public function testWaitHiddenWaitsForElementToDisappear(): void
     {
-        $page = $this->makePage([true, false]);
+        $page = $this->mockPage('isVisible');
+        $page->expects($this->exactly(2))
+            ->method('isVisible')
+            ->with('.loading', 100)
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $page->waitHidden('.loading', 500);
-
-        $this->assertSame(2, $page->visibilityChecks);
     }
 
     public function testWaitVisibleBuildsUsefulDefaultMessage(): void
     {
-        $page = $this->makePage([false]);
+        $page = $this->mockPage('isVisible');
+        $page->method('isVisible')->willReturn(false);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Element did not become visible: #missing');
@@ -61,26 +66,30 @@ final class CommonPageWaitTest extends TestCase
 
     public function testWaitForTextWaitsUntilTextAppears(): void
     {
-        $page = $this->makeTextPage(['Loading', 'Order confirmed']);
+        $page = $this->mockPage('getTextContent');
+        $page->expects($this->exactly(2))
+            ->method('getTextContent')
+            ->with('body', 1, true, 100)
+            ->willReturnOnConsecutiveCalls('Loading', 'Order confirmed');
 
         $page->waitForText('Order confirmed', 500);
-
-        $this->assertSame(2, $page->textChecks);
-        $this->assertSame('body', $page->lastSelector);
     }
 
     public function testWaitForTextSupportsScopedSelector(): void
     {
-        $page = $this->makeTextPage(['Saved']);
+        $page = $this->mockPage('getTextContent');
+        $page->expects($this->once())
+            ->method('getTextContent')
+            ->with('.notification', 1, true, 100)
+            ->willReturn('Saved');
 
         $page->waitForText('Saved', 500, '.notification');
-
-        $this->assertSame('.notification', $page->lastSelector);
     }
 
     public function testWaitForTextUsesProvidedFailureMessage(): void
     {
-        $page = $this->makeTextPage(['Still loading']);
+        $page = $this->mockPage('getTextContent');
+        $page->method('getTextContent')->willReturn('Still loading');
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Confirmation message did not appear.');
@@ -88,66 +97,16 @@ final class CommonPageWaitTest extends TestCase
         $page->waitForText('Done', 1, 'body', 'Confirmation message did not appear.');
     }
 
-    private function makePage(array $visibility = []): CommonPage
+    private function makePage(): CommonPage
     {
-        return new class ('en', '8.1.0', [], [], $visibility) extends CommonPage {
-            public int $visibilityChecks = 0;
-
-            private array $visibility;
-
-            public function __construct(string $locale, string $patchVersion, array $globals, array $customs, array $visibility)
-            {
-                parent::__construct($locale, $patchVersion, $globals, $customs);
-                $this->visibility = $visibility;
-            }
-
-            public function isVisible($selector, $timeout = 1000)
-            {
-                ++$this->visibilityChecks;
-
-                if ($this->visibility === []) {
-                    return false;
-                }
-
-                if (count($this->visibility) === 1) {
-                    return $this->visibility[0];
-                }
-
-                return array_shift($this->visibility);
-            }
-        };
+        return new CommonPage('en', '8.1.0', []);
     }
 
-    private function makeTextPage(array $contents): CommonPage
+    private function mockPage(string $method): CommonPage
     {
-        return new class ('en', '8.1.0', [], [], $contents) extends CommonPage {
-            public int $textChecks = 0;
-
-            public string $lastSelector = '';
-
-            private array $contents;
-
-            public function __construct(string $locale, string $patchVersion, array $globals, array $customs, array $contents)
-            {
-                parent::__construct($locale, $patchVersion, $globals, $customs);
-                $this->contents = $contents;
-            }
-
-            public function getTextContent($selector, $index = 1, $waitForSelector = true, $timeout = 3000)
-            {
-                ++$this->textChecks;
-                $this->lastSelector = $selector;
-
-                if ($this->contents === []) {
-                    return false;
-                }
-
-                if (count($this->contents) === 1) {
-                    return $this->contents[0];
-                }
-
-                return array_shift($this->contents);
-            }
-        };
+        return $this->getMockBuilder(CommonPage::class)
+            ->setConstructorArgs(['en', '8.1.0', []])
+            ->onlyMethods([$method])
+            ->getMock();
     }
 }

--- a/tests/Unit/Tests/ExtraHeadersFromEnvTest.php
+++ b/tests/Unit/Tests/ExtraHeadersFromEnvTest.php
@@ -40,7 +40,7 @@ final class ExtraHeadersFromEnvTest extends TestCase
 
     private function invoke(): void
     {
-        $suite = new class extends TestsSuite {
+        $suite = new class(loadGlobals: false, getBrowser: false) extends TestsSuite {
             public function callPreset(): void
             {
                 $this->presetExtraHeadersFromEnv();


### PR DESCRIPTION
Ajoute quelques helpers simples dans CommonPage pour les cas récurrents : attente de condition, visibilité, texte et clic suivi d’un rechargement. Ça évite beaucoup de petites répétitions quand on a de nombreuses suites de tests qui font régulièrement les mêmes choses.