### PR TITLE
Robustify wait helpers: TimeoutException + tighter deadline

### DIFF
--- a/src/Exceptions/TimeoutException.php
+++ b/src/Exceptions/TimeoutException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PrestaFlow\Library\Exceptions;
+
+class TimeoutException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Pages/CommonPage.php
+++ b/src/Pages/CommonPage.php
@@ -6,6 +6,7 @@ use Exception;
 use HeadlessChromium\Exception\ElementNotFoundException;
 use HeadlessChromium\Exception\OperationTimedOut;
 use HeadlessChromium\Page as DomPage;
+use PrestaFlow\Library\Exceptions\TimeoutException;
 use PrestaFlow\Library\Expects\Expect;
 use PrestaFlow\Library\Resolvers\Translations;
 use PrestaFlow\Library\Tests\TestsSuite;
@@ -532,16 +533,23 @@ class CommonPage
     public function waitUntil(callable $condition, int $timeout = 10000, string $message = 'Condition was not met.'): void
     {
         $deadline = microtime(true) + ($timeout / 1000);
+        $interval = 100000; // 100ms
 
-        do {
+        while (true) {
             if ($condition()) {
                 return;
             }
 
-            usleep(100000);
-        } while (microtime(true) < $deadline);
+            $remaining = $deadline - microtime(true);
+            if ($remaining <= 0) {
+                break;
+            }
 
-        throw new \RuntimeException($message);
+            // Cap the sleep so we don't overshoot the deadline.
+            usleep((int) min($interval, $remaining * 1_000_000));
+        }
+
+        throw new TimeoutException($message);
     }
 
     public function waitVisible($selector, int $timeout = 10000, ?string $message = null): void
@@ -564,10 +572,17 @@ class CommonPage
 
     public function waitForText(string $text, int $timeout = 10000, string $selector = 'body', ?string $message = null): void
     {
-        $this->waitUntil(
-            function () use ($selector, $text) {
-                $content = $this->getTextContent($selector, 1, true, 100);
+        $waitForSelector = true;
 
+        $this->waitUntil(
+            function () use ($selector, $text, &$waitForSelector) {
+                $content = $this->getTextContent($selector, 1, $waitForSelector, 100);
+                // Only wait for the selector on the first poll; subsequent
+                // polls only care about the text content.
+                $waitForSelector = false;
+
+                // getTextContent returns false on timeout and '' when the
+                // element has no text yet — is_string filters out the false.
                 return is_string($content) && str_contains($content, $text);
             },
             $timeout,

--- a/tests/Unit/Pages/CommonPageWaitTest.php
+++ b/tests/Unit/Pages/CommonPageWaitTest.php
@@ -3,6 +3,7 @@
 namespace PrestaFlow\Tests\Unit\Pages;
 
 use PHPUnit\Framework\TestCase;
+use PrestaFlow\Library\Exceptions\TimeoutException;
 use PrestaFlow\Library\Pages\CommonPage;
 
 final class CommonPageWaitTest extends TestCase
@@ -29,6 +30,32 @@ final class CommonPageWaitTest extends TestCase
         $this->expectExceptionMessage('Expected condition did not happen.');
 
         $page->waitUntil(fn () => false, 1, 'Expected condition did not happen.');
+    }
+
+    public function testWaitUntilThrowsTimeoutException(): void
+    {
+        $page = $this->makePage();
+
+        $this->expectException(TimeoutException::class);
+
+        $page->waitUntil(fn () => false, 1);
+    }
+
+    public function testWaitUntilRespectsDeadline(): void
+    {
+        $page = $this->makePage();
+
+        $start = microtime(true);
+        try {
+            $page->waitUntil(fn () => false, 200);
+        } catch (TimeoutException $e) {
+            // expected
+        }
+        $elapsedMs = (microtime(true) - $start) * 1000;
+
+        // Should be close to 200ms, well below 400ms (i.e. no 100ms overshoot per iteration).
+        $this->assertLessThan(350, $elapsedMs);
+        $this->assertGreaterThanOrEqual(200, $elapsedMs);
     }
 
     public function testWaitVisibleWaitsForVisibleElement(): void
@@ -67,12 +94,19 @@ final class CommonPageWaitTest extends TestCase
     public function testWaitForTextWaitsUntilTextAppears(): void
     {
         $page = $this->mockPage('getTextContent');
+        $calls = [];
         $page->expects($this->exactly(2))
             ->method('getTextContent')
-            ->with('body', 1, true, 100)
-            ->willReturnOnConsecutiveCalls('Loading', 'Order confirmed');
+            ->willReturnCallback(function (...$args) use (&$calls) {
+                $calls[] = $args;
+                return count($calls) === 1 ? 'Loading' : 'Order confirmed';
+            });
 
         $page->waitForText('Order confirmed', 500);
+
+        // First poll waits for the selector; subsequent polls skip it.
+        $this->assertSame(['body', 1, true, 100], $calls[0]);
+        $this->assertSame(['body', 1, false, 100], $calls[1]);
     }
 
     public function testWaitForTextSupportsScopedSelector(): void


### PR DESCRIPTION
Closes #57.

## Changes

**1. `TimeoutException` dédiée**
Nouvelle classe `PrestaFlow\Library\Exceptions\TimeoutException` qui étend `\RuntimeException` et implémente `ExceptionInterface`. `CommonPage::waitUntil()` la lance désormais à la place d'une `RuntimeException` nue. Comme elle hérite de `RuntimeException`, tous les `try/catch` existants continuent de fonctionner — c'est purement additif.

**2. Deadline respectée**
`waitUntil()` calcule le temps restant avant chaque `usleep()` et le plafonne à la valeur restante, donc l'attente réelle ne dépasse plus le `$timeout` annoncé de ~100 ms sur la dernière itération.

**3. Bonus `waitForText()`**
- Le `waitForSelector` de `getTextContent()` n'est activé que sur le 1ᵉʳ poll ; les polls suivants économisent les 100 ms internes.
- Commentaire ajouté pour justifier le `is_string($content)` (car `getTextContent` renvoie `false` en timeout et `''` sur texte vide).

## Tests

`vendor/bin/phpunit tests/Unit` → **OK (117 tests, 442 assertions)**.

Ajouts dans `CommonPageWaitTest` :
- `testWaitUntilThrowsTimeoutException` — vérifie le type d'exception.
- `testWaitUntilRespectsDeadline` — vérifie qu'un `waitUntil(fn () => false, 200)` termine sous 350 ms (au lieu de possiblement 300+ ms auparavant).
- `testWaitForTextWaitsUntilTextAppears` adapté au nouveau motif d'appel (`true` puis `false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)